### PR TITLE
Update public struct properties to be var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.1.0...HEAD)
 
+### Changed
+- Updated public let properties of public structs with memberwise initializers to be public var.
+
 ## [0.1.0](https://github.com/airbnb/epoxy-ios/compare/171f63da...0.1.0) - 2021-02-01
 
 ### Added

--- a/Sources/EpoxyCollectionView/CollectionView/ItemPath.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ItemPath.swift
@@ -28,9 +28,9 @@ public struct ItemPath: Hashable {
   }
 
   /// The item identified by the `dataID` on its corresponding `ItemModel`.
-  public let itemDataID: AnyHashable
+  public var itemDataID: AnyHashable
 
   /// The section in which the item referenced by this path located.
-  public let section: Section
+  public var section: Section
 
 }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/ItemCellMetadata.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/ItemCellMetadata.swift
@@ -16,7 +16,7 @@ public struct ItemCellMetadata {
 
   // MARK: Public
 
-  public let traitCollection: UITraitCollection
-  public let state: ItemCellState
-  public let animated: Bool
+  public var traitCollection: UITraitCollection
+  public var state: ItemCellState
+  public var animated: Bool
 }

--- a/Sources/EpoxyCore/Model/Providers/ViewDifferentiatorProviding.swift
+++ b/Sources/EpoxyCore/Model/Providers/ViewDifferentiatorProviding.swift
@@ -28,6 +28,6 @@ public struct ViewDifferentiator: Hashable {
 
   // MARK: Public
 
-  public let viewTypeDescription: String
-  public let styleID: AnyHashable?
+  public var viewTypeDescription: String
+  public var styleID: AnyHashable?
 }


### PR DESCRIPTION
## Change summary
There's not a good reason to keep these as `let`s, as these types have public memberwise `init`s and these properties don't need to be kept in sync.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] N/A, this is a trivial change

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
