### PR TITLE
Improve BarStackView APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated public let properties of public structs with memberwise initializers to be public var.
 - `BarStackView` now handles selection of bar models and can be used as an `EpoxyableView`.
+- The cases of `BarStackView.ZOrder` have been renamed to be more semantically accurate
 
 ## [0.1.0](https://github.com/airbnb/epoxy-ios/compare/171f63da...0.1.0) - 2021-02-01
 

--- a/Example/EpoxyExample.xcodeproj/project.pbxproj
+++ b/Example/EpoxyExample.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		2518441925B8E35A000B801F /* FlowLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2518441825B8E35A000B801F /* FlowLayoutViewController.swift */; };
 		2518441C25B8E38A000B801F /* ColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2518441B25B8E38A000B801F /* ColorView.swift */; };
 		25627B93232ABF0F00D7327A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25627B92232ABF0E00D7327A /* AppDelegate.swift */; };
-		25627B95232ABF0F00D7327A /* HighlightAndSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25627B94232ABF0F00D7327A /* HighlightAndSelectionViewController.swift */; };
+		25627B95232ABF0F00D7327A /* CompositionalLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25627B94232ABF0F00D7327A /* CompositionalLayoutViewController.swift */; };
 		25627B9A232ABF1000D7327A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 25627B99232ABF1000D7327A /* Assets.xcassets */; };
 		25627B9D232ABF1100D7327A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 25627B9B232ABF1100D7327A /* LaunchScreen.storyboard */; };
 		259863A225AE47710065024B /* UICollectionViewCompositionalLayout+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259863A125AE47710065024B /* UICollectionViewCompositionalLayout+List.swift */; };
@@ -24,6 +24,8 @@
 		A633B24025B6494D0095E464 /* BeloIpsum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A633B23F25B6494D0095E464 /* BeloIpsum.swift */; };
 		A633B24625B6507A0095E464 /* ImageMarquee.swift in Sources */ = {isa = PBXBuildFile; fileRef = A633B24525B6507A0095E464 /* ImageMarquee.swift */; };
 		A6358A3A25C4E4AE007051D5 /* PresentationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6358A3925C4E4AE007051D5 /* PresentationViewController.swift */; };
+		A667554125D2FEC400AC4FC8 /* CardContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A667554025D2FEC400AC4FC8 /* CardContainer.swift */; };
+		A667554425D3028D00AC4FC8 /* CardStackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A667554325D3028D00AC4FC8 /* CardStackViewController.swift */; };
 		A6990DCC25633D8600689965 /* Epoxy in Frameworks */ = {isa = PBXBuildFile; productRef = A6990DCB25633D8600689965 /* Epoxy */; };
 		A6F0928B25B9E983007D902B /* TextRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F0928A25B9E983007D902B /* TextRow.swift */; };
 		A6F0928F25B9ECC6007D902B /* ReadmeExamplesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F0928E25B9ECC6007D902B /* ReadmeExamplesViewController.swift */; };
@@ -38,7 +40,7 @@
 		2518441B25B8E38A000B801F /* ColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorView.swift; sourceTree = "<group>"; };
 		25627B8F232ABF0E00D7327A /* EpoxyExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EpoxyExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25627B92232ABF0E00D7327A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		25627B94232ABF0F00D7327A /* HighlightAndSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightAndSelectionViewController.swift; sourceTree = "<group>"; };
+		25627B94232ABF0F00D7327A /* CompositionalLayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionalLayoutViewController.swift; sourceTree = "<group>"; };
 		25627B99232ABF1000D7327A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		25627B9C232ABF1100D7327A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		25627B9E232ABF1100D7327A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -53,6 +55,8 @@
 		A633B23F25B6494D0095E464 /* BeloIpsum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeloIpsum.swift; sourceTree = "<group>"; };
 		A633B24525B6507A0095E464 /* ImageMarquee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMarquee.swift; sourceTree = "<group>"; };
 		A6358A3925C4E4AE007051D5 /* PresentationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationViewController.swift; sourceTree = "<group>"; };
+		A667554025D2FEC400AC4FC8 /* CardContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardContainer.swift; sourceTree = "<group>"; };
+		A667554325D3028D00AC4FC8 /* CardStackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardStackViewController.swift; sourceTree = "<group>"; };
 		A6F0928A25B9E983007D902B /* TextRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextRow.swift; sourceTree = "<group>"; };
 		A6F0928E25B9ECC6007D902B /* ReadmeExamplesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadmeExamplesViewController.swift; sourceTree = "<group>"; };
 		A6F0929225B9ED0C007D902B /* CounterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewController.swift; sourceTree = "<group>"; };
@@ -118,11 +122,12 @@
 			children = (
 				A6F0928D25B9EC8B007D902B /* Readme */,
 				25B6765E25AE883700C00B20 /* ProductViewController.swift */,
-				25627B94232ABF0F00D7327A /* HighlightAndSelectionViewController.swift */,
+				25627B94232ABF0F00D7327A /* CompositionalLayoutViewController.swift */,
 				BACF3E8B23DBB8DC0001CCD1 /* ShuffleViewController.swift */,
 				2E8B007723F4800000D82A31 /* CustomSelfSizingContentViewController.swift */,
 				25FEB79125AE431100F8EFBD /* MainViewController.swift */,
 				2518441825B8E35A000B801F /* FlowLayoutViewController.swift */,
+				A667554325D3028D00AC4FC8 /* CardStackViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -136,6 +141,7 @@
 				25B6766725AFA67100C00B20 /* ButtonRow.swift */,
 				A633B24525B6507A0095E464 /* ImageMarquee.swift */,
 				2518441B25B8E38A000B801F /* ColorView.swift */,
+				A667554025D2FEC400AC4FC8 /* CardContainer.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -258,7 +264,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A633B24625B6507A0095E464 /* ImageMarquee.swift in Sources */,
-				25627B95232ABF0F00D7327A /* HighlightAndSelectionViewController.swift in Sources */,
+				25627B95232ABF0F00D7327A /* CompositionalLayoutViewController.swift in Sources */,
 				BACF3E8C23DBB8DC0001CCD1 /* ShuffleViewController.swift in Sources */,
 				25627B93232ABF0F00D7327A /* AppDelegate.swift in Sources */,
 				25B6766825AFA67100C00B20 /* ButtonRow.swift in Sources */,
@@ -272,12 +278,14 @@
 				25B6765F25AE883700C00B20 /* ProductViewController.swift in Sources */,
 				A6F0928F25B9ECC6007D902B /* ReadmeExamplesViewController.swift in Sources */,
 				25FEB79225AE431100F8EFBD /* MainViewController.swift in Sources */,
+				A667554425D3028D00AC4FC8 /* CardStackViewController.swift in Sources */,
 				25B6766225AE898B00C00B20 /* ImageRow.swift in Sources */,
 				A633B24025B6494D0095E464 /* BeloIpsum.swift in Sources */,
 				A6F0929D25B9EFB9007D902B /* FormNavigationController.swift in Sources */,
 				2E8B007823F4800000D82A31 /* CustomSelfSizingContentViewController.swift in Sources */,
 				2518441925B8E35A000B801F /* FlowLayoutViewController.swift in Sources */,
 				259863A225AE47710065024B /* UICollectionViewCompositionalLayout+List.swift in Sources */,
+				A667554125D2FEC400AC4FC8 /* CardContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/EpoxyExample/ViewControllers/CardStackViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/CardStackViewController.swift
@@ -33,7 +33,7 @@ final class CardStackViewController: CollectionViewController {
               .didSelect { _ in
                 print("Selected Text Row \(dataID)")
               },
-          ]),
+          ], selectedBackgroundColor: .secondarySystemBackground),
           style: .init(card: .init()))
       }),
     ]

--- a/Example/EpoxyExample/ViewControllers/CardStackViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/CardStackViewController.swift
@@ -1,0 +1,41 @@
+// Created by eric_horacek on 2/9/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Epoxy
+import UIKit
+
+final class CardStackViewController: CollectionViewController {
+
+  // MARK: Lifecycle
+
+  init() {
+    super.init(layout: UICollectionViewCompositionalLayout.listNoDividers)
+    setSections(sections, animated: false)
+  }
+
+  // MARK: Private
+
+  private var sections: [SectionModel] {
+    [
+      SectionModel(items: (0..<10).map { (dataID: Int) in
+        CardContainer<BarStackView>.itemModel(
+          dataID: dataID,
+          content: .init(models: [
+            ImageMarquee.barModel(
+              content: .init(imageURL: URL(string: "https://picsum.photos/id/\(dataID + 310)/600/300")!),
+              style: .init(height: 150, contentMode: .scaleAspectFill))
+              .didSelect { _ in
+                print("Selected Image Marquee \(dataID)")
+              },
+            TextRow.barModel(
+              content: .init(title: "Row \(dataID)", body: BeloIpsum.paragraph(count: 1, seed: dataID)),
+              style: .small)
+              .didSelect { _ in
+                print("Selected Text Row \(dataID)")
+              },
+          ]),
+          style: .init(card: .init()))
+      }),
+    ]
+  }
+}

--- a/Example/EpoxyExample/ViewControllers/CompositionalLayoutViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/CompositionalLayoutViewController.swift
@@ -4,7 +4,7 @@
 import Epoxy
 import UIKit
 
-final class HighlightAndSelectionViewController: CollectionViewController {
+final class CompositionalLayoutViewController: CollectionViewController {
 
   // MARK: Lifecycle
 

--- a/Example/EpoxyExample/ViewControllers/MainViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/MainViewController.swift
@@ -19,11 +19,12 @@ final class MainViewController: NavigationController {
 
   enum Example: CaseIterable {
     case readme
-    case highlightAndSelection
+    case product
+    case compositionalLayout
+    case cardStack
+    case flowLayout
     case shuffle
     case customSelfSizing
-    case product
-    case flowLayout
   }
 
   // MARK: Private
@@ -84,7 +85,10 @@ final class MainViewController: NavigationController {
       layout: UICollectionViewCompositionalLayout.list,
       sections: [
         SectionModel(items: Example.allCases.map { example in
-          TextRow.itemModel(dataID: example, content: .init(title: example.title), style: .small)
+          TextRow.itemModel(
+            dataID: example,
+            content: .init(title: example.title, body: example.body),
+            style: .small)
             .didSelect { [weak self] _ in
               self?.state.showExample = example
             }
@@ -101,8 +105,8 @@ final class MainViewController: NavigationController {
       viewController = ReadmeExamplesViewController(didSelect: { [weak self] example in
         self?.state.showReadmeExample = example
       })
-    case .highlightAndSelection:
-      viewController = HighlightAndSelectionViewController()
+    case .compositionalLayout:
+      viewController = CompositionalLayoutViewController()
     case .shuffle:
       viewController = ShuffleViewController()
     case .customSelfSizing:
@@ -111,6 +115,8 @@ final class MainViewController: NavigationController {
       viewController = ProductViewController()
     case .flowLayout:
       viewController = FlowLayoutViewController()
+    case .cardStack:
+      viewController = CardStackViewController()
     }
     viewController.title = example.title
     return viewController
@@ -125,14 +131,35 @@ extension MainViewController.Example {
       return "Readme examples"
     case .customSelfSizing:
       return "Custom self-sizing cells"
-    case .highlightAndSelection:
-      return "Highlight and selection demo"
+    case .compositionalLayout:
+      return "Compositional Layout"
     case .shuffle:
       return "Shuffle demo"
     case .product:
       return "Product Detail Page"
     case .flowLayout:
       return "Flow Layout demo"
+    case .cardStack:
+      return "Card Stack"
+    }
+  }
+
+  var body: String {
+    switch self {
+    case .readme:
+      return "All of the examples from the README"
+    case .customSelfSizing:
+      return "A CollectionView with custom self-sizing cells"
+    case .compositionalLayout:
+      return "A CollectionView with a UICollectionViewCompositionalLayout"
+    case .shuffle:
+      return "A CollectionView with cells that are randomly shuffled on a timer"
+    case .product:
+      return "An example that combines collections, bars, and presentations"
+    case .flowLayout:
+      return "A CollectionView with a UICollectionViewFlowLayout"
+    case .cardStack:
+      return "A CollectionView with BarStackView items that have a card drawn around each stack"
     }
   }
 }

--- a/Example/EpoxyExample/Views/CardContainer.swift
+++ b/Example/EpoxyExample/Views/CardContainer.swift
@@ -1,0 +1,141 @@
+// Created by eric_horacek on 2/9/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Epoxy
+import UIKit
+
+// MARK: - CardContainer
+
+/// A container that draws a card around a content view.
+final class CardContainer<ContentView: EpoxyableView>: UIView, EpoxyableView {
+
+  // MARK: Lifecycle
+
+  init(style: Style) {
+    self.style = style.card
+    if ContentView.Style.self == Never.self {
+      contentView = ContentView()
+    } else {
+      contentView = ContentView(style: style.content)
+    }
+    super.init(frame: .zero)
+    addSubviews()
+    setUpConstraints()
+    applyStyle()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  struct Style: Hashable {
+    init(content: ContentView.Style, card: CardStyle) {
+      self.content = content
+      self.card = card
+    }
+
+    init(card: CardStyle) where ContentView.Style == Never {
+      self.card = card
+    }
+
+    fileprivate var content: ContentView.Style!
+    fileprivate var card: CardStyle
+  }
+
+  struct CardStyle: Hashable {
+    var cornerRadius: CGFloat = 10
+    var layoutMargins = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
+    var cardBackgroundColor = UIColor.white
+    var borderColor = UIColor.lightGray
+    var borderWidth: CGFloat = 1
+    var shadowColor = UIColor.black
+    var shadowOffset = CGSize(width: 0, height: 2)
+    var shadowRadius: CGFloat = 4
+    var shadowOpacity: Float = 0.2
+  }
+
+  let contentView: ContentView
+
+  func setContent(_ content: ContentView.Content, animated: Bool) {
+    contentView.setContent(content, animated: animated)
+  }
+
+  // MARK: Private
+
+  private let style: CardStyle
+
+  private lazy var contentContainer: UIView = {
+    let view = UIView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.clipsToBounds = true
+    view.layer.cornerRadius = style.cornerRadius
+    view.backgroundColor = style.cardBackgroundColor
+    view.layer.borderWidth = style.borderWidth
+    view.layer.borderColor = style.borderColor.cgColor
+    return view
+  }()
+
+  private lazy var shadow: UIView = {
+    let view = UIView()
+    view.backgroundColor = .white
+    view.clipsToBounds = false
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.layer.cornerRadius = style.cornerRadius
+    view.layer.shadowColor = style.shadowColor.cgColor
+    view.layer.shadowOffset = style.shadowOffset
+    view.layer.shadowOpacity = style.shadowOpacity
+    view.layer.shadowRadius = style.shadowRadius
+    return view
+  }()
+
+  private func addSubviews() {
+    addSubview(shadow)
+    contentContainer.addSubview(contentView)
+    addSubview(contentContainer)
+  }
+
+  private func setUpConstraints() {
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      shadow.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+      shadow.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      shadow.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      shadow.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+      contentView.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+      contentView.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+      contentView.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+      contentView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
+      contentContainer.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+      contentContainer.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      contentContainer.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      contentContainer.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+    ])
+  }
+
+  private func applyStyle() {
+    layoutMargins = style.layoutMargins
+  }
+
+}
+
+// MARK: - UIEdgeInsets + Hashable
+
+extension UIEdgeInsets: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(left)
+    hasher.combine(right)
+    hasher.combine(top)
+    hasher.combine(bottom)
+  }
+}
+
+// MARK: - CGSize + Hashable
+
+extension CGSize: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(height)
+    hasher.combine(width)
+  }
+}

--- a/Example/EpoxyExample/Views/CardContainer.swift
+++ b/Example/EpoxyExample/Views/CardContainer.swift
@@ -40,6 +40,7 @@ final class CardContainer<ContentView: EpoxyableView>: UIView, EpoxyableView {
       self.card = card
     }
 
+    // swiftlint:disable implicitly_unwrapped_optional
     fileprivate var content: ContentView.Style!
     fileprivate var card: CardStyle
   }

--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -8,10 +8,6 @@ import UIKit
 
 /// A container of bar views that insets its view controller's safe area insets.
 public protocol BarContainer: BarStackView {
-  /// - Parameter didUpdateCoordinator: A closure that's called after a bar coordinator has been
-  ///   created.
-  init(didUpdateCoordinator: ((AnyBarCoordinating) -> Void)?)
-
   /// The coordinators for each of the bars within this stack, ordered from top to bottom.
   var coordinators: [AnyBarCoordinating] { get }
 
@@ -55,6 +51,10 @@ public enum BarContainerInsetBehavior: Equatable {
 
 /// The internal behavior of a `BarContainer`.
 protocol InternalBarContainer: BarContainer {
+
+  /// A closure that's called after a bar coordinator has been created.
+  var didUpdateCoordinator: ((AnyBarCoordinating) -> Void)? { get set }
+
   /// The position of this bar container within its view controller's view.
   var position: BarContainerPosition { get }
 

--- a/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
@@ -116,9 +116,10 @@ final class BarInstaller<Container: BarContainer> {
   }
 
   private func installContainer(in view: UIView, with models: [BarModeling], animated: Bool) {
-    let container = Container(didUpdateCoordinator: { [weak self] coordinator in
+    let container = Container()
+    container.didUpdateCoordinator = { [weak self] coordinator in
       self?.updateCoordinatorProperties(coordinator)
-    })
+    }
     container.add(to: view)
     container.viewController = viewController
     container.setBars(models, animated: animated)

--- a/Sources/EpoxyBars/BarInstaller/BarStackView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarStackView.swift
@@ -311,6 +311,7 @@ public class BarStackView: UIStackView, EpoxyableView {
     wrapper.willDisplayBar = { [weak self] bar in
       self?.handleWillDisplayBar(bar)
     }
+    wrapper.didUpdateCoordinator = didUpdateCoordinator
     wrapper.setModel(model, animated: false)
     return wrapper
   }

--- a/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
@@ -103,7 +103,7 @@ public final class BarWrapperView: UIView {
   var willDisplayBar: ((_ bar: UIView) -> Void)?
 
   /// The ordering of this bar within a bar stack.
-  var zOrder = BarStackView.ZOrder.topToBottom
+  var zOrder = BarStackView.ZOrder.firstToLast
 
   /// The background color drawn behind this bar when it is selected.
   var selectedBackgroundColor: UIColor? {
@@ -252,9 +252,9 @@ public final class BarWrapperView: UIView {
       // We add one to `defaultLow` to allow for content to use this as its compression resistance
       // priority to be compressed.
       switch zOrder {
-      case .bottomToTop:
+      case .lastToFirst:
         bottom.priority = UILayoutPriority(rawValue: UILayoutPriority.defaultLow.rawValue + 1)
-      case .topToBottom:
+      case .firstToLast:
         top.priority = UILayoutPriority(rawValue: UILayoutPriority.defaultLow.rawValue + 1)
       }
       NSLayoutConstraint.activate([top, bottom, leading, trailing])

--- a/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
@@ -14,16 +14,7 @@ public final class BarWrapperView: UIView {
 
   // MARK: Lifecycle
 
-  init(
-    zOrder: BarStackView.ZOrder,
-    selectedBackgroundColor: UIColor?,
-    willDisplayBar: ((_ bar: UIView) -> Void)? = nil,
-    didUpdateCoordinator: ((AnyBarCoordinating) -> Void)? = nil)
-  {
-    self.zOrder = zOrder
-    self.selectedBackgroundColor = selectedBackgroundColor
-    self.willDisplayBar = willDisplayBar
-    self.didUpdateCoordinator = didUpdateCoordinator
+  init() {
     super.init(frame: .zero)
     layoutMargins = .zero
     translatesAutoresizingMaskIntoConstraints = false
@@ -105,16 +96,34 @@ public final class BarWrapperView: UIView {
 
   // MARK: Internal
 
-  var canHighlight: Bool {
-    _model?.isSelectable ?? false
+  /// A closure that's called after a bar coordinator has been created.
+  var didUpdateCoordinator: ((_ coordinator: AnyBarCoordinating) -> Void)?
+
+  /// A closure that will be invoked prior to adding the bar view to the view hierarchy.
+  var willDisplayBar: ((_ bar: UIView) -> Void)?
+
+  /// The ordering of this bar within a bar stack.
+  var zOrder = BarStackView.ZOrder.topToBottom
+
+  /// The background color drawn behind this bar when it is selected.
+  var selectedBackgroundColor: UIColor? {
+    didSet {
+      guard selectedBackgroundColor != oldValue else { return }
+      updateSelected()
+    }
   }
 
-  func updateSelection(isSelected: Bool) {
-    if isSelected && _model?.isSelectable == true {
-      backgroundColor = selectedBackgroundColor
-    } else {
-      backgroundColor = nil
+  /// Whether this bar should draw its selected state.
+  var isSelected = false {
+    didSet {
+      guard isSelected != oldValue else { return }
+      updateSelected()
     }
+  }
+
+  /// Whether this wrapper can be highlighted.
+  var canHighlight: Bool {
+    _model?.isSelectable ?? false
   }
 
   func handleSelection(animated: Bool) {
@@ -124,25 +133,23 @@ public final class BarWrapperView: UIView {
 
   // MARK: Private
 
-  private let zOrder: BarStackView.ZOrder
-
-  private let selectedBackgroundColor: UIColor?
-
   /// The current bar model.
   private var _model: InternalBarModeling?
 
   /// The coordinator wrapper: a type-erased `AnyBarCoordinator`.
   private var _coordinator: AnyBarCoordinating?
 
-  /// A closure that will be invoked prior to adding the bar view to the view hierarchy.
-  private let willDisplayBar: ((_ bar: UIView) -> Void)?
-
-  /// A closure that's called after a bar coordinator has been created.
-  private let didUpdateCoordinator: ((_ coordinator: AnyBarCoordinating) -> Void)?
-
   /// The original bottom layout margins of the bar before they were overridden by this view's
   /// layout margins.
   private var originalViewLayoutMargins: UIEdgeInsets?
+
+  private func updateSelected() {
+    if isSelected && _model?.isSelectable == true {
+      backgroundColor = selectedBackgroundColor
+    } else {
+      backgroundColor = nil
+    }
+  }
 
   private func setModel(_ model: InternalBarCoordinating?, animated: Bool) {
     let oldValue = _model

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -16,7 +16,7 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
 
   public required init() {
     super.init()
-    zOrder = .bottomToTop
+    zOrder = .lastToFirst
     addSubviews()
     constrainSubviews()
   }

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -14,13 +14,14 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
 
   // MARK: Lifecycle
 
-  public init(didUpdateCoordinator: ((AnyBarCoordinating) -> Void)?) {
-    super.init(style: .bottomToTop, didUpdateCoordinator: didUpdateCoordinator)
-
+  public required init() {
+    super.init()
+    zOrder = .bottomToTop
     addSubviews()
     constrainSubviews()
   }
 
+  @available(*, unavailable)
   required public init(style: Style) {
     fatalError("init(style:) has not been implemented")
   }

--- a/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
+++ b/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
@@ -16,7 +16,8 @@ public final class InputAccessoryBarStackView: UIView {
   // MARK: Lifecycle
 
   public init(bars: [BarModeling] = []) {
-    barStack = BarStackView(style: .bottomToTop)
+    barStack = BarStackView()
+    barStack.zOrder = .bottomToTop
     barStack.setBars(bars, animated: false)
     super.init(frame: .zero)
     addSubview(barStack)

--- a/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
+++ b/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
@@ -17,7 +17,7 @@ public final class InputAccessoryBarStackView: UIView {
 
   public init(bars: [BarModeling] = []) {
     barStack = BarStackView()
-    barStack.zOrder = .bottomToTop
+    barStack.zOrder = .lastToFirst
     barStack.setBars(bars, animated: false)
     super.init(frame: .zero)
     addSubview(barStack)

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -14,15 +14,11 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
 
   // MARK: Lifecycle
 
-  public init(didUpdateCoordinator: ((AnyBarCoordinating) -> Void)?) {
-    super.init(style: .topToBottom, didUpdateCoordinator: didUpdateCoordinator)
-
+  public required init() {
+    super.init()
+    zOrder = .topToBottom
     addSubviews()
     constrainSubviews()
-  }
-
-  required public init(style: Style) {
-    fatalError("init(style:) has not been implemented")
   }
 
   // MARK: Public

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -16,7 +16,7 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
 
   public required init() {
     super.init()
-    zOrder = .topToBottom
+    zOrder = .firstToLast
     addSubviews()
     constrainSubviews()
   }


### PR DESCRIPTION
## Change summary
- Remove the style, instead favoring public vars and content properties for settable properties
- Add an example that uses a BarStackView in a CollectionView within a CardContainer

<img width="320" alt="Screenshot" src="https://user-images.githubusercontent.com/438313/107419057-3598a180-6acc-11eb-9db2-eb64f0893cc9.png">

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
