### PR TITLE
Update build status badge to only be for CI on master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img  width="300" alt="Epoxy logo" src="docs/images/logo.svg" >
 
-[![Build Status](https://github.com/airbnb/epoxy-ios/workflows/CI/badge.svg)](https://github.com/airbnb/epoxy-ios/actions)
+[![Build Status](https://github.com/airbnb/epoxy-ios/workflows/CI/badge.svg?branch=master)](https://github.com/airbnb/epoxy-ios/actions?query=branch%3Amaster+workflow%3ACI)
 [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 [![Version](https://img.shields.io/cocoapods/v/Epoxy.svg)](https://cocoapods.org/pods/Epoxy)
 [![Platform](https://img.shields.io/badge/platform-ios-lightgrey.svg?style=flat)](https://cocoapods.org/pods/Epoxy)


### PR DESCRIPTION
## Change summary
We don't want this badge to be for all CI checks, which would make it failing more often than we'd like

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] View badge

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
