### PR TITLE
Enable CollectionView prefetching by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated public let properties of public structs with memberwise initializers to be public var.
 - `BarStackView` now handles selection of bar models and can be used as an `EpoxyableView`.
 - The cases of `BarStackView.ZOrder` have been renamed to be more semantically accurate
+- Enables `CollectionView` prefetching by default, as the issues preventing it from being enabled by
+  default are now resolved in recent iOS versions
 
 ## [0.1.0](https://github.com/airbnb/epoxy-ios/compare/171f63da...0.1.0) - 2021-02-01
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -12,7 +12,7 @@ public final class CollectionViewConfiguration {
 
   public init(
     usesBatchUpdatesForAllReloads: Bool = false,
-    usesCellPrefetching: Bool = false,
+    usesCellPrefetching: Bool = true,
     usesAccurateScrollToItem: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
@@ -45,7 +45,7 @@ public final class CollectionViewConfiguration {
   ///
   /// If this is set to `true`, then cell-prefetching will be turned on by default.
   ///
-  /// Defaults to `false`.
+  /// Defaults to `true`.
   public let usesCellPrefetching: Bool
 
   /// Collection view does not accurately scroll to items if they're self-sized, due to it using


### PR DESCRIPTION
## Change summary
We've verified that the primary issues with this behavior are no longer affecting newer iOS versions.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
