### PR TITLE
Support animated moves in bar stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The cases of `BarStackView.ZOrder` have been renamed to be more semantically accurate
 - Enables `CollectionView` prefetching by default, as the issues preventing it from being enabled by
   default are now resolved in recent iOS versions
+- Support animated moves in `BarStackView`
 
 ## [0.1.0](https://github.com/airbnb/epoxy-ios/compare/171f63da...0.1.0) - 2021-02-01
 


### PR DESCRIPTION
## Change summary
If we call `insertArrangedSubview(_:at:)` as part of an animation transaction on an arranged subview, it will be moved with an animation. As such, we adopt this behavior in `BarStackView` to better respect the intent of the `animated` parameter to `setModels(_:animated:)`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
