### PR TITLE
Crossfade between bars of the same view type with different style IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.1.0...HEAD)
 
 ### Changed
-- Updated public let properties of public structs with memberwise initializers to be public var.
-- `BarStackView` now handles selection of bar models and can be used as an `EpoxyableView`.
+- Updated public let properties of public structs with memberwise initializers to be public var
+- `BarStackView` now handles selection of bar models and can be used as an `EpoxyableView`
 - The cases of `BarStackView.ZOrder` have been renamed to be more semantically accurate
 - Enables `CollectionView` prefetching by default, as the issues preventing it from being enabled by
   default are now resolved in recent iOS versions
 - Support animated moves in `BarStackView`
 - Fixed ordering when inserting and removing bar models
+- Crossfade between bars of the same view type with different style IDs in `BarStackView`
 
 ## [0.1.0](https://github.com/airbnb/epoxy-ios/compare/171f63da...0.1.0) - 2021-02-01
 

--- a/Sources/EpoxyBars/BarCoordinator/CoordinatedBarModel.swift
+++ b/Sources/EpoxyBars/BarCoordinator/CoordinatedBarModel.swift
@@ -104,7 +104,7 @@ extension CoordinatedBarModel: InternalBarCoordinating {
 
 extension CoordinatedBarModel: Diffable {
   public var diffIdentifier: AnyHashable {
-    DiffIdentifier(dataID: dataID, viewClass: .init(viewClass), styleID: styleID)
+    DiffIdentifier(dataID: dataID, viewClass: .init(viewClass))
   }
 
   public func isDiffableItemEqual(to otherDiffableItem: Diffable) -> Bool {

--- a/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarWrapperView.swift
@@ -174,7 +174,12 @@ public final class BarWrapperView: UIView {
 
     _model = model
 
-    if let oldValue = oldValue, let view = view, oldValue.diffIdentifier == model.diffIdentifier {
+    if
+      let oldValue = oldValue,
+      let view = view,
+      oldValue.diffIdentifier == model.diffIdentifier,
+      oldValue.styleID == model.styleID
+    {
       if !oldValue.isDiffableItemEqual(to: model) {
         model.configureContent(view, traitCollection: traitCollection, animated: animated)
       }

--- a/Sources/EpoxyBars/BarModel/BarModel.swift
+++ b/Sources/EpoxyBars/BarModel/BarModel.swift
@@ -230,7 +230,7 @@ extension BarModel: InternalBarCoordinating {
 
 extension BarModel: Diffable {
   public var diffIdentifier: AnyHashable {
-    DiffIdentifier(dataID: dataID, viewClass: .init(View.self), styleID: styleID)
+    DiffIdentifier(dataID: dataID, viewClass: .init(View.self))
   }
 
   public func isDiffableItemEqual(to otherDiffableItem: Diffable) -> Bool {
@@ -276,5 +276,4 @@ struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
   // The `View.Type` wrapped in `ObjectIdentifier` since `AnyClass` is not `Hashable`.
   var viewClass: ObjectIdentifier
-  var styleID: AnyHashable?
 }

--- a/Sources/EpoxyBars/BarModel/InternalBarModeling.swift
+++ b/Sources/EpoxyBars/BarModel/InternalBarModeling.swift
@@ -9,7 +9,7 @@ import UIKit
 /// A model that can provide a bar view to a `BarStackView`.
 ///
 /// Used to reference a `BarModel` without a generic type.
-protocol InternalBarModeling: Diffable, EpoxyModeled {
+protocol InternalBarModeling: Diffable, EpoxyModeled, StyleIDProviding {
   /// Constructs a configured bar view.
   func makeConfiguredView(traitCollection: UITraitCollection) -> UIView
 


### PR DESCRIPTION
## Change summary
If two bar views are of the same type but have different style IDs, we should just crossfade between them, rather than treating them as a delete and insert. As such, we remove the `styleID` from the `DiffIdentifier` and check it in `BarWrapperView` instead.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
