### PR TITLE
Add result builders for SectionModels, ItemModels, BarModels, PresentationModels, and NavigationModels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.1.0...HEAD)
 
+### Added
+- Added result builders for SectionModels, ItemModels, BarModels, PresentationModels, and NavigationModels
+
 ### Changed
 - Updated public let properties of public structs with memberwise initializers to be public var
 - `BarStackView` now handles selection of bar models and can be used as an `EpoxyableView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.1.0...HEAD)
 
 ### Added
-- Added result builders for SectionModels, ItemModels, BarModels, PresentationModels, and NavigationModels
+- Added result builders for `SectionModel`, `ItemModel`, `BarModel`, `PresentationModel`, and
+  `NavigationModel`
+- Added initializers and methods to `CollectionViewController` that take an array of `ItemModel`s
+  and transparently wrap them in a `SectionModel` for consumers.
 
 ### Changed
 - Updated public let properties of public structs with memberwise initializers to be public var

--- a/Example/EpoxyExample/ViewControllers/Readme/BottomButtonViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/BottomButtonViewController.swift
@@ -21,13 +21,11 @@ class BottomButtonViewController: UIViewController {
     viewController: self,
     bars: bars)
 
-  private var bars: [BarModeling] {
-    [
-      ButtonRow.barModel(
-        content: .init(text: "Tap me!"),
-        behaviors: .init(didTap: {
-          // Handle button selection
-        })),
-    ]
+  @BarModelBuilder private var bars: [BarModeling] {
+    ButtonRow.barModel(
+      content: .init(text: "Click me!"),
+      behaviors: .init(didTap: {
+        // Handle button selection
+      }))
   }
 }

--- a/Example/EpoxyExample/ViewControllers/Readme/CounterViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/CounterViewController.swift
@@ -24,19 +24,17 @@ class CounterViewController: CollectionViewController {
     didSet { setSections(sections, animated: true) }
   }
 
-  private var sections: [SectionModel] {
-    [
-      SectionModel(items: [
-        TextRow.itemModel(
-          dataID: DataID.row,
-          content: .init(
-            title: "Count \(count)",
-            body: "Tap to increment"),
-          style: .large)
-          .didSelect { [weak self] _ in
-            self?.count += 1
-          },
-      ]),
-    ]
+  @SectionModelBuilder private var sections: [SectionModel] {
+    SectionModel {
+      TextRow.itemModel(
+        dataID: DataID.row,
+        content: .init(
+          title: "Count \(count)",
+          body: "Tap to increment"),
+        style: .large)
+        .didSelect { [weak self] _ in
+          self?.count += 1
+        }
+    }
   }
 }

--- a/Example/EpoxyExample/ViewControllers/Readme/CounterViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/CounterViewController.swift
@@ -11,7 +11,7 @@ class CounterViewController: CollectionViewController {
 
   init() {
     super.init(layout: UICollectionViewCompositionalLayout.list)
-    setSections(sections, animated: false)
+    setItems(items, animated: false)
   }
 
   // MARK: Private
@@ -21,20 +21,18 @@ class CounterViewController: CollectionViewController {
   }
 
   private var count = 0 {
-    didSet { setSections(sections, animated: true) }
+    didSet { setItems(items, animated: true) }
   }
 
-  @SectionModelBuilder private var sections: [SectionModel] {
-    SectionModel {
-      TextRow.itemModel(
-        dataID: DataID.row,
-        content: .init(
-          title: "Count \(count)",
-          body: "Tap to increment"),
-        style: .large)
-        .didSelect { [weak self] _ in
-          self?.count += 1
-        }
-    }
+  @ItemModelBuilder private var items: [ItemModeling] {
+    TextRow.itemModel(
+      dataID: DataID.row,
+      content: .init(
+        title: "Count \(count)",
+        body: "Tap to increment"),
+      style: .large)
+      .didSelect { [weak self] _ in
+        self?.count += 1
+      }
   }
 }

--- a/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
@@ -30,31 +30,25 @@ final class FormNavigationController: NavigationController {
     didSet { setStack(stack, animated: true) }
   }
 
-  private var stack: [NavigationModel?] {
-    [step1, step2]
-  }
-
-  private var step1: NavigationModel {
-    .root(dataID: DataID.step1) { [weak self] in
+  @NavigationModelBuilder private var stack: [NavigationModel] {
+    NavigationModel.root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
         self?.state.showStep2 = true
       })
     }
-  }
 
-  private var step2: NavigationModel? {
-    guard state.showStep2 else { return nil }
-
-    return NavigationModel(
-      dataID: DataID.step2,
-      makeViewController: {
-        Step2ViewController(didTapNext: {
-          // Navigate away from this step.
+    if state.showStep2 {
+      NavigationModel(
+        dataID: DataID.step2,
+        makeViewController: {
+          Step2ViewController(didTapNext: {
+            // Navigate away from this step.
+          })
+        },
+        remove: { [weak self] in
+          self?.state.showStep2 = false
         })
-      },
-      remove: { [weak self] in
-        self?.state.showStep2 = false
-      })
+    }
   }
 }
 

--- a/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
@@ -27,7 +27,7 @@ final class FormNavigationController: NavigationController {
   }
 
   @NavigationModelBuilder private var stack: [NavigationModel] {
-    NavigationModel.root(dataID: DataID.step1) { [weak self] in
+    .root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
         self?.showStep2 = true
       })

--- a/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/FormNavigationController.swift
@@ -18,26 +18,22 @@ final class FormNavigationController: NavigationController {
 
   // MARK: Private
 
-  private struct State {
-    var showStep2 = false
-  }
-
   private enum DataID {
     case step1, step2
   }
 
-  private var state = State() {
+  private var showStep2 = false {
     didSet { setStack(stack, animated: true) }
   }
 
   @NavigationModelBuilder private var stack: [NavigationModel] {
     NavigationModel.root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
-        self?.state.showStep2 = true
+        self?.showStep2 = true
       })
     }
 
-    if state.showStep2 {
+    if showStep2 {
       NavigationModel(
         dataID: DataID.step2,
         makeViewController: {
@@ -46,7 +42,7 @@ final class FormNavigationController: NavigationController {
           })
         },
         remove: { [weak self] in
-          self?.state.showStep2 = false
+          self?.showStep2 = false
         })
     }
   }

--- a/Example/EpoxyExample/ViewControllers/Readme/PresentationViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/PresentationViewController.swift
@@ -31,20 +31,20 @@ final class PresentationViewController: UIViewController {
     didSet { setPresentation(presentation, animated: true) }
   }
 
-  private var presentation: PresentationModel? {
-    guard showDetail else { return nil }
-
-    return PresentationModel(
-      dataID: DataID.detail,
-      presentation: .system,
-      makeViewController: { [weak self] in
-        DetailViewController(didTapDismiss: {
+  @PresentationModelBuilder private var presentation: PresentationModel? {
+    if showDetail {
+      PresentationModel(
+        dataID: DataID.detail,
+        presentation: .system,
+        makeViewController: { [weak self] in
+          DetailViewController(didTapDismiss: {
+            self?.showDetail = false
+          })
+        },
+        dismiss: { [weak self] in
           self?.showDetail = false
         })
-      },
-      dismiss: { [weak self] in
-        self?.showDetail = false
-      })
+    }
   }
 
 }

--- a/Example/EpoxyExample/ViewControllers/Readme/ReadmeExamplesViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/Readme/ReadmeExamplesViewController.swift
@@ -64,17 +64,15 @@ enum ReadmeExample: CaseIterable {
 
     return CollectionViewController(
       layout: UICollectionViewCompositionalLayout.list,
-      sections: [
-        SectionModel(items: [
-          TextRow.itemModel(
-            dataID: DataID.row,
-            content: .init(title: "Tap me!"),
-            style: .small)
-            .didSelect { _ in
-              // Handle selection
-            },
-        ]),
-      ])
+      items: {
+        TextRow.itemModel(
+          dataID: DataID.row,
+          content: .init(title: "Tap me!"),
+          style: .small)
+          .didSelect { _ in
+            // Handle selection
+          }
+      })
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -131,21 +131,19 @@ class CounterViewController: CollectionViewController {
   }
 
   private var count = 0 {
-    didSet { setSections(sections, animated: true) }
+    didSet { setItems(items, animated: true) }
   }
 
-  @SectionModelBuilder private var sections: [SectionModel] {
-    SectionModel {
-      TextRow.itemModel(
-        dataID: DataID.row,
-        content: .init(
-          title: "Count \(count)",
-          body: "Tap to increment"),
-        style: .large)
-        .didSelect { [weak self] _ in
-          self?.count += 1
-        }
-    }
+  @ItemModelBuilder private var items: [ItemModeling] {
+    TextRow.itemModel(
+      dataID: DataID.row,
+      content: .init(
+        title: "Count \(count)",
+        body: "Tap to increment"),
+      style: .large)
+      .didSelect { [weak self] _ in
+        self?.count += 1
+      }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ class CounterViewController: CollectionViewController {
     setSections(sections, animated: false)
   }
 
-  private enum DataID {
+  enum DataID {
     case row
   }
 
-  private var count = 0 {
+  var count = 0 {
     didSet { setItems(items, animated: true) }
   }
 
-  @ItemModelBuilder private var items: [ItemModeling] {
+  @ItemModelBuilder var items: [ItemModeling] {
     TextRow.itemModel(
       dataID: DataID.row,
       content: .init(
@@ -176,11 +176,11 @@ class BottomButtonViewController: UIViewController {
     bottomBarInstaller.install()
   }
 
-  private lazy var bottomBarInstaller = BottomBarInstaller(
+  lazy var bottomBarInstaller = BottomBarInstaller(
     viewController: self,
     bars: bars)
 
-  @BarModelBuilder private var bars: [BarModeling] {
+  @BarModelBuilder var bars: [BarModeling] {
     ButtonRow.barModel(
       content: .init(text: "Click me!"),
       behaviors: .init(didTap: {
@@ -219,26 +219,22 @@ class FormNavigationController: NavigationController {
     setStack(stack, animated: false)
   }
 
-  private struct State {
-    var showStep2 = false
-  }
-
-  private enum DataID {
+  enum DataID {
     case step1, step2
   }
 
-  private var state = State() {
+  var showStep2 = false {
     didSet { setStack(stack, animated: true) }
   }
 
-  @NavigationModelBuilder private var stack: [NavigationModel] {
+  @NavigationModelBuilder var stack: [NavigationModel] {
     NavigationModel.root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
-        self?.state.showStep2 = true
+        self?.showStep2 = true
       })
     }
 
-    if state.showStep2 {
+    if showStep2 {
       NavigationModel(
         dataID: DataID.step2,
         makeViewController: {
@@ -247,7 +243,7 @@ class FormNavigationController: NavigationController {
           })
         },
         remove: { [weak self] in
-          self?.state.showStep2 = false
+          self?.showStep2 = false
         })
     }
   }
@@ -283,32 +279,28 @@ class PresentationViewController: UIViewController {
     setPresentation(presentation, animated: true)
   }
 
-  private enum DataID {
+  enum DataID {
     case detail
   }
 
-  private var showDetail = true {
-    didSet {
-      setPresentation(presentation, animated: true)
-    }
+  var showDetail = true {
+    didSet { setPresentation(presentation, animated: true) }
   }
 
-  private var presentation: PresentationModel? {
-    guard showDetail else { return nil }
-
-    return PresentationModel(
-      dataID: DataID.detail,
-      presentation: .system,
-      makeViewController: { [weak self] in
-        DetailViewController(didTapDismiss: {
-          // Handle tapping the dismiss button:
+  @PresentationModelBuilder private var presentation: PresentationModel? {
+    if showDetail {
+      PresentationModel(
+        dataID: DataID.detail,
+        presentation: .system,
+        makeViewController: { [weak self] in
+          DetailViewController(didTapDismiss: {
+            self?.showDetail = false
+          })
+        },
+        dismiss: { [weak self] in
           self?.showDetail = false
         })
-      },
-      dismiss: { [weak self] in
-        // Or swiping down the sheet:
-        self?.showDetail = false
-      })
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -90,17 +90,15 @@ enum DataID {
 let viewController = CollectionViewController(
   layout: UICollectionViewCompositionalLayout
     .list(using: .init(appearance: .plain)),
-  sections: [
-    SectionModel(items: [
-      TextRow.itemModel(
-        dataID: DataID.row,
-        content: .init(title: "Tap me!"),
-        style: .small)
-        .didSelect { _ in
-          // Handle selection
-        }
-    ])
-  ])
+  items: {
+    TextRow.itemModel(
+      dataID: DataID.row,
+      content: .init(title: "Tap me!"),
+      style: .small)
+      .didSelect { _ in
+        // Handle selection
+      }
+  })
 ```
 
 </td>
@@ -136,20 +134,18 @@ class CounterViewController: CollectionViewController {
     didSet { setSections(sections, animated: true) }
   }
 
-  private var sections: [SectionModel] {
-    [
-      SectionModel(items: [
-        TextRow.itemModel(
-          dataID: DataID.row,
-          content: .init(
-            title: "Count \(count)",
-            body: "Tap to increment"),
-          style: .large)
-          .didSelect { [weak self] _ in
-            self?.count += 1
-          }
-      ])
-    ]
+  @SectionModelBuilder private var sections: [SectionModel] {
+    SectionModel {
+      TextRow.itemModel(
+        dataID: DataID.row,
+        content: .init(
+          title: "Count \(count)",
+          body: "Tap to increment"),
+        style: .large)
+        .didSelect { [weak self] _ in
+          self?.count += 1
+        }
+    }
   }
 }
 ```
@@ -186,14 +182,12 @@ class BottomButtonViewController: UIViewController {
     viewController: self,
     bars: bars)
 
-  private var bars: [BarModeling] {
-    [
-      ButtonRow.barModel(
-        content: .init(text: "Click me!"),
-        behaviors: .init(didTap: {
-          // Handle button selection
-        }))
-    ]
+  @BarModelBuilder private var bars: [BarModeling] {
+    ButtonRow.barModel(
+      content: .init(text: "Click me!"),
+      behaviors: .init(didTap: {
+        // Handle button selection
+      }))
   }
 }
 ```
@@ -239,31 +233,25 @@ class FormNavigationController: NavigationController {
     didSet { setStack(stack, animated: true) }
   }
 
-  private var stack: [NavigationModel?] {
-    [step1, step2]
-  }
-
-  private var step1: NavigationModel {
-    .root(dataID: DataID.step1) { [weak self] in
+  @NavigationModelBuilder private var stack: [NavigationModel] {
+    NavigationModel.root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
         self?.state.showStep2 = true
       })
     }
-  }
 
-  private var step2: NavigationModel? {
-    guard state.showStep2 else { return nil }
-
-    return NavigationModel(
-      dataID: DataID.step2,
-      makeViewController: {
-        Step2ViewController(didTapNext: {
-          // Navigate away from this step.
+    if state.showStep2 {
+      NavigationModel(
+        dataID: DataID.step2,
+        makeViewController: {
+          Step2ViewController(didTapNext: {
+            // Navigate away from this step.
+          })
+        },
+        remove: { [weak self] in
+          self?.state.showStep2 = false
         })
-      },
-      remove: { [weak self] in
-        self?.state.showStep2 = false
-      })
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ class FormNavigationController: NavigationController {
   }
 
   @NavigationModelBuilder var stack: [NavigationModel] {
-    NavigationModel.root(dataID: DataID.step1) { [weak self] in
+    .root(dataID: DataID.step1) { [weak self] in
       Step1ViewController(didTapNext: {
         self?.showStep2 = true
       })

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ class PresentationViewController: UIViewController {
     didSet { setPresentation(presentation, animated: true) }
   }
 
-  @PresentationModelBuilder private var presentation: PresentationModel? {
+  @PresentationModelBuilder var presentation: PresentationModel? {
     if showDetail {
       PresentationModel(
         dataID: DataID.detail,

--- a/Sources/EpoxyBars/BarModel/BarModelBuilder.swift
+++ b/Sources/EpoxyBars/BarModel/BarModelBuilder.swift
@@ -1,74 +1,7 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
+import EpoxyCore
+
 /// A result builder that enables a DSL for building arrays of bar models.
-@resultBuilder
-public struct BarModelBuilder {
-  public typealias Expression = BarModeling
-  public typealias Component = [BarModeling]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#else
-/// A result builder that enables a DSL for building arrays of bar models.
-@_functionBuilder
-public struct BarModelBuilder {
-  public typealias Expression = BarModeling
-  public typealias Component = [BarModeling]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#endif
+public typealias BarModelBuilder = EpoxyModelArrayBuilder<BarModeling>

--- a/Sources/EpoxyBars/BarModel/BarModelBuilder.swift
+++ b/Sources/EpoxyBars/BarModel/BarModelBuilder.swift
@@ -1,0 +1,74 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A result builder that enables a DSL for building arrays of bar models.
+@resultBuilder
+public struct BarModelBuilder {
+  public typealias Expression = BarModeling
+  public typealias Component = [BarModeling]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#else
+/// A result builder that enables a DSL for building arrays of bar models.
+@_functionBuilder
+public struct BarModelBuilder {
+  public typealias Expression = BarModeling
+  public typealias Component = [BarModeling]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#endif

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
@@ -30,6 +30,14 @@ public final class BottomBarInstaller: NSObject {
     installer.setBars(bars, animated: false)
   }
 
+  public convenience init(
+    viewController: UIViewController,
+    avoidsKeyboard: Bool = false,
+    @BarModelBuilder bars: () -> [BarModeling])
+  {
+    self.init(viewController: viewController, bars: bars())
+  }
+
   // MARK: Public
 
   /// The container installed in the view controller's view that contains the bar stack.

--- a/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
+++ b/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
@@ -30,6 +30,10 @@ public final class InputAccessoryBarStackView: UIView {
     autoresizingMask = .flexibleHeight
   }
 
+  public convenience init(@BarModelBuilder bars: () -> [BarModeling]) {
+    self.init(bars: bars())
+  }
+
   @available(*, unavailable)
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
@@ -28,6 +28,13 @@ public final class TopBarInstaller: NSObject {
     installer.setBars(bars, animated: false)
   }
 
+  public convenience init(
+    viewController: UIViewController,
+    @BarModelBuilder bars: () -> [BarModeling])
+  {
+    self.init(viewController: viewController, bars: bars())
+  }
+
   // MARK: Public
 
   /// The container installed in the view controller's view that contains the bar stack.

--- a/Sources/EpoxyCollectionView/Models/ItemModel/ItemModelBuilder.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/ItemModelBuilder.swift
@@ -1,0 +1,74 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A result builder that enables a DSL for building arrays of item models.
+@resultBuilder
+public struct ItemModelBuilder {
+  public typealias Expression = ItemModeling
+  public typealias Component = [ItemModeling]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#else
+/// A result builder that enables a DSL for building arrays of item models.
+@_functionBuilder
+public struct ItemModelBuilder {
+  public typealias Expression = ItemModeling
+  public typealias Component = [ItemModeling]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#endif

--- a/Sources/EpoxyCollectionView/Models/ItemModel/ItemModelBuilder.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/ItemModelBuilder.swift
@@ -1,74 +1,17 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
+import EpoxyCore
+
 /// A result builder that enables a DSL for building arrays of item models.
-@resultBuilder
-public struct ItemModelBuilder {
-  public typealias Expression = ItemModeling
-  public typealias Component = [ItemModeling]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#else
-/// A result builder that enables a DSL for building arrays of item models.
-@_functionBuilder
-public struct ItemModelBuilder {
-  public typealias Expression = ItemModeling
-  public typealias Component = [ItemModeling]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#endif
+///
+/// For example:
+/// ```
+/// @ItemModelBuilder var items: [ItemModeling] {
+///    MyView.itemModel(…)
+///    MyOtherView.itemModel(…)
+/// }
+/// ```
+///
+/// Will return an array containing two item models.
+public typealias ItemModelBuilder = EpoxyModelArrayBuilder<ItemModeling>

--- a/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
@@ -18,6 +18,10 @@ public struct SectionModel: EpoxyModeled {
     self.items = items
   }
 
+  public init(dataID: AnyHashable? = nil, @ItemModelBuilder items: () -> [ItemModeling]) {
+    self.init(dataID: dataID, items: items())
+  }
+
   // MARK: Public
 
   public var storage = EpoxyModelStorage()

--- a/Sources/EpoxyCollectionView/Models/SectionModel/SectionModelBuilder.swift
+++ b/Sources/EpoxyCollectionView/Models/SectionModel/SectionModelBuilder.swift
@@ -1,74 +1,17 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
+import EpoxyCore
+
 /// A result builder that enables a DSL for building arrays of section models.
-@resultBuilder
-public struct SectionModelBuilder {
-  public typealias Expression = SectionModel
-  public typealias Component = [SectionModel]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#else
-/// A result builder that enables a DSL for building arrays of section models.
-@_functionBuilder
-public struct SectionModelBuilder {
-  public typealias Expression = SectionModel
-  public typealias Component = [SectionModel]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#endif
+///
+/// For example:
+/// ```
+/// @SectionModelBuilder var sections: [SectionModel] {
+///    SectionModel(…) { … }
+///    SectionModel(…) { … }
+/// }
+/// ```
+///
+/// Will return an array containing two section models.
+public typealias SectionModelBuilder = EpoxyModelArrayBuilder<SectionModel>

--- a/Sources/EpoxyCollectionView/Models/SectionModel/SectionModelBuilder.swift
+++ b/Sources/EpoxyCollectionView/Models/SectionModel/SectionModelBuilder.swift
@@ -1,0 +1,74 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A result builder that enables a DSL for building arrays of section models.
+@resultBuilder
+public struct SectionModelBuilder {
+  public typealias Expression = SectionModel
+  public typealias Component = [SectionModel]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#else
+/// A result builder that enables a DSL for building arrays of section models.
+@_functionBuilder
+public struct SectionModelBuilder {
+  public typealias Expression = SectionModel
+  public typealias Component = [SectionModel]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#endif

--- a/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
+++ b/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
@@ -21,6 +21,14 @@ open class CollectionViewController: UIViewController {
   }
 
   /// Initializes a collection view controller and configures its collection view with the provided
+  /// layout and a single section containing the given items once the view loads.
+  ///
+  /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
+  public convenience init(layout: UICollectionViewLayout, items: [ItemModeling]) {
+    self.init(layout: layout, sections: [SectionModel(items: items)])
+  }
+
+  /// Initializes a collection view controller and configures its collection view with the provided
   /// layout and sections once the view loads.
   public convenience init(
     layout: UICollectionViewLayout,
@@ -30,12 +38,14 @@ open class CollectionViewController: UIViewController {
   }
 
   /// Initializes a collection view controller and configures its collection view with the provided
-  /// layout and items once the view loads.
+  /// layout and a single section containing the given items once the view loads.
+  ///
+  /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
   public convenience init(
     layout: UICollectionViewLayout,
     @ItemModelBuilder items: () -> [ItemModeling])
   {
-    self.init(layout: layout, sections: [SectionModel(items: items())])
+    self.init(layout: layout, items: items())
   }
 
   @available(*, unavailable)
@@ -89,6 +99,17 @@ open class CollectionViewController: UIViewController {
       return
     }
     collectionView.setSections(sections, animated: animated)
+  }
+
+  /// Updates the sections of the `collectionView` to a single section with the provided `items`,
+  /// optionally animating the differences from the current sections.
+  ///
+  /// If `collectionView` has not yet been loaded, the section containing `items` is stored until
+  /// the view loads and set on `collectionView` non-animatedly at that point.
+  ///
+  /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
+  public func setItems(_ items: [ItemModeling], animated: Bool) {
+    setSections([SectionModel(items: items)], animated: animated)
   }
 
   // MARK: Private

--- a/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
+++ b/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
@@ -20,6 +20,24 @@ open class CollectionViewController: UIViewController {
     super.init(nibName: nil, bundle: nil)
   }
 
+  /// Initializes a collection view controller and configures its collection view with the provided
+  /// layout and sections once the view loads.
+  public convenience init(
+    layout: UICollectionViewLayout,
+    @SectionModelBuilder sections: () -> [SectionModel])
+  {
+    self.init(layout: layout, sections: sections())
+  }
+
+  /// Initializes a collection view controller and configures its collection view with the provided
+  /// layout and items once the view loads.
+  public convenience init(
+    layout: UICollectionViewLayout,
+    @ItemModelBuilder items: () -> [ItemModeling])
+  {
+    self.init(layout: layout, sections: [SectionModel(items: items())])
+  }
+
   @available(*, unavailable)
   public required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
+++ b/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
@@ -1,0 +1,74 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A generic result builder that enables a DSL for building arrays of Epoxy models.
+@resultBuilder
+public struct EpoxyModelArrayBuilder<Model> {
+  public typealias Expression = Model
+  public typealias Component = [Model]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#else
+/// A generic result builder that enables a DSL for building arrays of Epoxy models.
+@_functionBuilder
+public struct EpoxyModelArrayBuilder<Model> {
+  public typealias Expression = Model
+  public typealias Component = [Model]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+}
+#endif

--- a/Sources/EpoxyNavigationController/NavigationController.swift
+++ b/Sources/EpoxyNavigationController/NavigationController.swift
@@ -98,6 +98,20 @@ open class NavigationController: UINavigationController {
     queue.enqueue(stack.compactMap { $0 }, animated: animated, from: self)
   }
 
+  /// Updates the navigation stack to the provided array of navigation models, optionally animating
+  /// the transition.
+  ///
+  /// Only the differences between the previous stack and the provided stack are applied as changes
+  /// to the view controller hierarchy.
+  ///
+  /// If a transition is in progress when this method is called, the provided stack is queued for
+  /// subsequent presentation following the completion of the transition.
+  ///
+  /// Conceptually similar to `setSections(_:animated:)` for Epoxy models.
+  public func setStack(_ stack: [NavigationModel], animated: Bool) {
+    queue.enqueue(stack, animated: animated, from: self)
+  }
+
   // MARK: Private
 
   private let queue = NavigationQueue()

--- a/Sources/EpoxyNavigationController/NavigationModelBuilder.swift
+++ b/Sources/EpoxyNavigationController/NavigationModelBuilder.swift
@@ -1,0 +1,66 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A result builder that enables a DSL for building arrays of navigation models.
+@resultBuilder
+public struct NavigationModelBuilder {
+  public typealias Expression = NavigationModel
+  public typealias Component = [NavigationModel]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+}
+#else
+/// A result builder that enables a DSL for building arrays of navigation models.
+@_functionBuilder
+public struct NavigationModelBuilder {
+  public typealias Expression = NavigationModel
+  public typealias Component = [NavigationModel]
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    children.flatMap { $0 }
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    children ?? []
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+}
+#endif

--- a/Sources/EpoxyNavigationController/NavigationModelBuilder.swift
+++ b/Sources/EpoxyNavigationController/NavigationModelBuilder.swift
@@ -1,66 +1,25 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
+import EpoxyCore
+
 /// A result builder that enables a DSL for building arrays of navigation models.
-@resultBuilder
-public struct NavigationModelBuilder {
-  public typealias Expression = NavigationModel
-  public typealias Component = [NavigationModel]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-}
-#else
-/// A result builder that enables a DSL for building arrays of navigation models.
-@_functionBuilder
-public struct NavigationModelBuilder {
-  public typealias Expression = NavigationModel
-  public typealias Component = [NavigationModel]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-}
-#endif
+///
+/// For example:
+/// ```
+/// @NavigationModelBuilder var stack: [NavigationModel] {
+///   NavigationModel.root(…)
+///
+///   if showStep1 {
+///     NavigationModel(…)
+///   }
+///
+///   if showStep2 {
+///     NavigationModel(…)
+///   }
+/// }
+/// ```
+///
+/// Will return an array of containing three navigation models when both `showStep1` and `showStep2`
+/// are `true`
+public typealias NavigationModelBuilder = EpoxyModelArrayBuilder<NavigationModel>

--- a/Sources/EpoxyPresentations/PresentationModelBuilder.swift
+++ b/Sources/EpoxyPresentations/PresentationModelBuilder.swift
@@ -3,6 +3,21 @@
 
 #if swift(>=5.4)
 /// A result builder that enables a DSL for building an optional presentation model.
+///
+/// For example:
+/// ```
+/// @PresentationModelBuilder var presentation: PresentationModel? {
+///    if showA {
+///      PresentationModel(…)
+///    }
+///    if showB {
+///      PresentationModel(…)
+///    }
+/// }
+/// ```
+///
+/// Will return a `nil` presentation model if `showA` and `showB` are false, else will return the
+/// first non-`nil` presentation model.
 @resultBuilder
 public struct PresentationModelBuilder {
   public typealias Expression = PresentationModel
@@ -51,6 +66,21 @@ public struct PresentationModelBuilder {
 }
 #else
 /// A result builder that enables a DSL for building an optional presentation model.
+///
+/// For example:
+/// ```
+/// @PresentationModelBuilder var presentation: PresentationModel? {
+///    if showA {
+///      PresentationModel(…)
+///    }
+///    if showB {
+///      PresentationModel(…)
+///    }
+/// }
+/// ```
+///
+/// Will return a `nil` presentation model if `showA` and `showB` are false, else will return the
+/// first non-`nil` presentation model.
 @_functionBuilder
 public struct PresentationModelBuilder {
   public typealias Expression = PresentationModel

--- a/Sources/EpoxyPresentations/PresentationModelBuilder.swift
+++ b/Sources/EpoxyPresentations/PresentationModelBuilder.swift
@@ -1,0 +1,100 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+#if swift(>=5.4)
+/// A result builder that enables a DSL for building an optional presentation model.
+@resultBuilder
+public struct PresentationModelBuilder {
+  public typealias Expression = PresentationModel
+  public typealias Component = PresentationModel?
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    expression
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    for child in children {
+      if let child = child {
+        return child
+      }
+    }
+    return nil
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    if let child = children {
+      return child
+    }
+    return nil
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    for child in components {
+      if let child = child {
+        return child
+      }
+    }
+    return nil
+  }
+}
+#else
+/// A result builder that enables a DSL for building an optional presentation model.
+@_functionBuilder
+public struct PresentationModelBuilder {
+  public typealias Expression = PresentationModel
+  public typealias Component = PresentationModel?
+
+  public static func buildExpression(_ expression: Expression) -> Component {
+    expression
+  }
+
+  public static func buildBlock(_ children: Component...) -> Component {
+    for child in children {
+      if let child = child {
+        return child
+      }
+    }
+    return nil
+  }
+
+  public static func buildBlock(_ component: Component) -> Component {
+    component
+  }
+
+  public static func buildOptional(_ children: Component?) -> Component {
+    if let child = children {
+      return child
+    }
+    return nil
+  }
+
+  public static func buildEither(first child: Component) -> Component {
+    child
+  }
+
+  public static func buildEither(second child: Component) -> Component {
+    child
+  }
+
+  public static func buildArray(_ components: [Component]) -> Component {
+    for child in components {
+      if let child = child {
+        return child
+      }
+    }
+    return nil
+  }
+}
+#endif

--- a/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
+++ b/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
@@ -1,0 +1,120 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import EpoxyCore
+import Nimble
+import Quick
+import UIKit
+
+final class EpoxyModelBuilderArraySpec: QuickSpec {
+  typealias TestBuilder = EpoxyModelArrayBuilder<Int>
+
+  struct BuilderTest {
+    init(@TestBuilder _ build: @escaping () -> [Int]) {
+      models = build()
+    }
+    var models: [Int]
+  }
+
+  override func spec() {
+    context("with a single model") {
+      it("should build the model") {
+        let builder = BuilderTest {
+          1
+        }
+        expect(builder.models) == [1]
+      }
+    }
+
+    context("with multiple models") {
+      it("should build the models") {
+        let builder = BuilderTest {
+          1
+          2
+        }
+        expect(builder.models) == [1, 2]
+      }
+    }
+
+    context("with an if condition") {
+      context("when the condition is false") {
+        it("should not include the model in the condition") {
+          let condition = false
+          let builder = BuilderTest {
+            if condition {
+              1
+            }
+            2
+          }
+          expect(builder.models) == [2]
+        }
+      }
+
+      context("when the condition is true") {
+        it("should include the model in the condition") {
+          let condition = true
+          let builder = BuilderTest {
+            if condition {
+              1
+            }
+            2
+          }
+          expect(builder.models) == [1, 2]
+        }
+      }
+    }
+
+    context("with an if-else condition") {
+      context("when the condition is false") {
+        it("should include the model in the else condition") {
+          let condition = false
+          let builder = BuilderTest {
+            if condition {
+              1
+            } else {
+              2
+            }
+            3
+          }
+          expect(builder.models) == [2, 3]
+        }
+      }
+
+      context("when the condition is true") {
+        it("should include the model in the if condition") {
+          let condition = true
+          let builder = BuilderTest {
+            if condition {
+              1
+            } else {
+              2
+            }
+            3
+          }
+          expect(builder.models) == [1, 3]
+        }
+      }
+    }
+
+    // Result builders only work with for loops in Swift 5.4+
+    #if swift(>=5.4)
+    context("with a for loop") {
+      it("should include the models in the loop") {
+        let builder = BuilderTest {
+          for dataID in 1...10 where dataID % 2 == 0 {
+            dataID
+          }
+        }
+        expect(builder.models) == [2, 4, 6, 8, 10]
+      }
+    }
+    #endif
+
+    context("with no models") {
+      it("should build an empty array") {
+        let builder = BuilderTest {}
+        expect(builder.models) == []
+      }
+    }
+  }
+}

--- a/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
+++ b/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
@@ -1,0 +1,165 @@
+// Created by eric_horacek on 3/15/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Nimble
+import Quick
+import UIKit
+
+@testable import EpoxyPresentations
+
+final class PresentationModelBuilderSpec: QuickSpec {
+  struct TestBuilder {
+    init(@PresentationModelBuilder _ build: @escaping () -> PresentationModel?) {
+      model = build()
+    }
+    var model: PresentationModel?
+  }
+
+  override func spec() {
+    context("with a single presentation model") {
+      it("should build the first presentation") {
+        let builder = TestBuilder {
+          PresentationModel(
+            dataID: "1",
+            presentation: .system,
+            makeViewController: UIViewController.init,
+            dismiss: {})
+        }
+        expect(builder.model?.dataID as? String) == "1"
+      }
+    }
+
+    context("with multiple presentation model") {
+      it("should build the first presentation") {
+        let builder = TestBuilder {
+          PresentationModel(
+            dataID: "1",
+            presentation: .system,
+            makeViewController: UIViewController.init,
+            dismiss: {})
+          PresentationModel(
+            dataID: "2",
+            presentation: .system,
+            makeViewController: UIViewController.init,
+            dismiss: {})
+        }
+        expect(builder.model?.dataID as? String) == "1"
+      }
+    }
+
+    context("with an if condition") {
+      context("when the condition is false") {
+        it("should build the first conditional presentation") {
+          let condition = false
+          let builder = TestBuilder {
+            if condition {
+              PresentationModel(
+                dataID: "1",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            }
+            PresentationModel(
+              dataID: "2",
+              presentation: .system,
+              makeViewController: UIViewController.init,
+              dismiss: {})
+          }
+          expect(builder.model?.dataID as? String) == "2"
+        }
+      }
+
+      context("when the condition is true") {
+        it("should build the first conditional presentation") {
+          let condition = true
+          let builder = TestBuilder {
+            if condition {
+              PresentationModel(
+                dataID: "1",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            }
+            PresentationModel(
+              dataID: "2",
+              presentation: .system,
+              makeViewController: UIViewController.init,
+              dismiss: {})
+          }
+          expect(builder.model?.dataID as? String) == "1"
+        }
+      }
+    }
+
+    context("with an if-else condition") {
+      context("when the condition is false") {
+        it("should build the first conditional presentation") {
+          let condition = false
+          let builder = TestBuilder {
+            if condition {
+              PresentationModel(
+                dataID: "1",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            } else {
+              PresentationModel(
+                dataID: "2",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            }
+          }
+          expect(builder.model?.dataID as? String) == "2"
+        }
+      }
+
+      context("when the condition is true") {
+        it("should build the first conditional presentation") {
+          let condition = true
+          let builder = TestBuilder {
+            if condition {
+              PresentationModel(
+                dataID: "1",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            } else {
+              PresentationModel(
+                dataID: "2",
+                presentation: .system,
+                makeViewController: UIViewController.init,
+                dismiss: {})
+            }
+          }
+          expect(builder.model?.dataID as? String) == "1"
+        }
+      }
+    }
+
+    // Result builders only work with for loops in Swift 5.4+
+    #if swift(>=5.4)
+    context("with a for loop") {
+      it("should build the first non-nil presentation") {
+        let builder = TestBuilder {
+          for dataID in 1...10 where dataID % 2 == 0 {
+            PresentationModel(
+              dataID: dataID,
+              presentation: .system,
+              makeViewController: UIViewController.init,
+              dismiss: {})
+          }
+        }
+        expect(builder.model?.dataID as? Int) == 2
+      }
+    }
+    #endif
+
+    context("with no presentation models") {
+      it("should build a nil model") {
+        let builder = TestBuilder {}
+        expect(builder.model).to(beNil())
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Change summary
This gives us a syntax that's much closer to SwiftUI, while still keeping the method signatures across the board.

I'll update all of the examples to use this new syntax in a follow up, since some of the new features require Swift 5.4.

### Example

```swift
@SectionModelBuilder private var sections: [SectionModel] {
  SectionModel {
    TextRow.itemModel(
      dataID: DataID.row,
      content: .init(
        title: "Count \(count)",
        body: "Tap to increment"),
      style: .large)
      .didSelect { [weak self] _ in
        self?.count += 1
      }
  }
```

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Built and ran on Xcode 12.4, 12.3
- [x] Added unit tests

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
