### PR TITLE
Add support for Array and Optional expressions to model result builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.2.0...HEAD)
 
+### Added
+- Added support for `Array` and `Optional` expressions to model result builders
+
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 
 ### Added

--- a/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
+++ b/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
@@ -12,6 +12,17 @@ public struct EpoxyModelArrayBuilder<Model> {
     [expression]
   }
 
+  public static func buildExpression(_ expression: Component) -> Component {
+    expression
+  }
+
+  public static func buildExpression(_ expression: Expression?) -> Component {
+    if let expression = expression {
+      return [expression]
+    }
+    return []
+  }
+
   public static func buildBlock(_ children: Component...) -> Component {
     children.flatMap { $0 }
   }
@@ -45,6 +56,17 @@ public struct EpoxyModelArrayBuilder<Model> {
 
   public static func buildExpression(_ expression: Expression) -> Component {
     [expression]
+  }
+
+  public static func buildExpression(_ expression: Component) -> Component {
+    expression
+  }
+
+  public static func buildExpression(_ expression: Expression?) -> Component {
+    if let expression = expression {
+      return [expression]
+    }
+    return []
   }
 
   public static func buildBlock(_ children: Component...) -> Component {

--- a/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
+++ b/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
@@ -17,7 +17,7 @@ final class EpoxyModelBuilderArraySpec: QuickSpec {
   }
 
   override func spec() {
-    context("with a single model") {
+    context("with a single model expression") {
       it("should build the model") {
         let builder = BuilderTest {
           1
@@ -26,13 +26,59 @@ final class EpoxyModelBuilderArraySpec: QuickSpec {
       }
     }
 
-    context("with multiple models") {
+    context("with multiple model expressions") {
       it("should build the models") {
         let builder = BuilderTest {
           1
           2
         }
         expect(builder.models) == [1, 2]
+      }
+    }
+
+    context("with an array expression of models") {
+      context("when non-empty") {
+        it("should include the array models") {
+          let builder = BuilderTest {
+            [1, 2, 3]
+            4
+          }
+          expect(builder.models) == [1, 2, 3, 4]
+        }
+      }
+
+      context("when empty") {
+        it("should omit the array models") {
+          let builder = BuilderTest {
+            []
+            4
+          }
+          expect(builder.models) == [4]
+        }
+      }
+    }
+
+    context("with an optional expression of models") {
+      context("that evaluates to a non-nil value") {
+        it("should include the optional model") {
+          let optionalInt: Int? = 1
+          let builder = BuilderTest {
+            optionalInt
+            2
+          }
+          expect(builder.models) == [1, 2]
+        }
+      }
+
+      context("that evaluates to a nil value") {
+        it("should omit the optional model") {
+          let optionalInt: Int? = nil
+          let builder = BuilderTest {
+            optionalInt
+            2
+          }
+          expect(builder.models) == [2]
+        }
       }
     }
 


### PR DESCRIPTION
## Change summary
This ensures that we can include both arrays and optional models in result builders. Without these changes, they result in a syntax error.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
