### PR TITLE
Add support for Optional expressions to PresentationModel result builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for `Array` and `Optional` expressions to model result builders
+- Added support for `Optional` expressions to `PresentationModel` result builders
 
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 

--- a/Sources/EpoxyPresentations/PresentationModelBuilder.swift
+++ b/Sources/EpoxyPresentations/PresentationModelBuilder.swift
@@ -27,6 +27,10 @@ public struct PresentationModelBuilder {
     expression
   }
 
+  public static func buildExpression(_ expression: Component) -> Component {
+    expression
+  }
+
   public static func buildBlock(_ children: Component...) -> Component {
     for child in children {
       if let child = child {
@@ -87,6 +91,10 @@ public struct PresentationModelBuilder {
   public typealias Component = PresentationModel?
 
   public static func buildExpression(_ expression: Expression) -> Component {
+    expression
+  }
+
+  public static func buildExpression(_ expression: Component) -> Component {
     expression
   }
 

--- a/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
+++ b/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
@@ -16,7 +16,7 @@ final class PresentationModelBuilderSpec: QuickSpec {
   }
 
   override func spec() {
-    context("with a single presentation model") {
+    context("with a single presentation model expression") {
       it("should build the first presentation") {
         let builder = TestBuilder {
           PresentationModel(
@@ -29,7 +29,7 @@ final class PresentationModelBuilderSpec: QuickSpec {
       }
     }
 
-    context("with multiple presentation model") {
+    context("with multiple presentation model expressions") {
       it("should build the first presentation") {
         let builder = TestBuilder {
           PresentationModel(
@@ -44,6 +44,42 @@ final class PresentationModelBuilderSpec: QuickSpec {
             dismiss: {})
         }
         expect(builder.model?.dataID as? String) == "1"
+      }
+    }
+
+    context("with an optional presentation model expression") {
+      context("that evaluates to a non-nil value") {
+        it("should build the first non-nil presentation") {
+          let optionalPresentation: PresentationModel? = PresentationModel(
+            dataID: "1",
+            presentation: .system,
+            makeViewController: UIViewController.init,
+            dismiss: {})
+          let builder = TestBuilder {
+            optionalPresentation
+            PresentationModel(
+              dataID: "2",
+              presentation: .system,
+              makeViewController: UIViewController.init,
+              dismiss: {})
+          }
+          expect(builder.model?.dataID as? String) == "1"
+        }
+      }
+
+      context("that evaluates to a nil value") {
+        it("should build the first non-nil presentation") {
+          let optionalPresentation: PresentationModel? = nil
+          let builder = TestBuilder {
+            optionalPresentation
+            PresentationModel(
+              dataID: "2",
+              presentation: .system,
+              makeViewController: UIViewController.init,
+              dismiss: {})
+          }
+          expect(builder.model?.dataID as? String) == "2"
+        }
       }
     }
 


### PR DESCRIPTION
## Change summary
This change allows you to extract out a presentation method into a local computed property.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Wrote automated tests

## Pull request checklist
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
