### PR TITLE
Make SectionModel data ID required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mitigated a `EXC_BAD_ACCESS` crash that caused by a bad `nonnull` bridge in `CollectionViewCell`.
 - Fixed an issue where styles were not being used in the `diffIdentifier` calculation of `GroupItems`.
 
+### Changed
+- The SectionModel initializer now requires a data ID to make it harder to have sections with
+  duplicate identity, resulting in a runtime warning and potentially unexpected diffing behavior.
+
 ## [0.5.0](https://github.com/airbnb/epoxy-ios/compare/0.4.0...0.5.0) - 2021-06-23
 
 ### Added

--- a/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
@@ -11,14 +11,12 @@ public struct SectionModel: EpoxyModeled {
 
   // MARK: Lifecycle
 
-  public init(dataID: AnyHashable? = nil, items: [ItemModeling]) {
-    if let dataID = dataID {
-      self.dataID = dataID
-    }
+  public init(dataID: AnyHashable, items: [ItemModeling]) {
+    self.dataID = dataID
     self.items = items
   }
 
-  public init(dataID: AnyHashable? = nil, @ItemModelBuilder items: () -> [ItemModeling]) {
+  public init(dataID: AnyHashable, @ItemModelBuilder items: () -> [ItemModeling]) {
     self.init(dataID: dataID, items: items())
   }
 
@@ -77,4 +75,18 @@ extension SectionModel: CallbackContextEpoxyModeled {
   /// There's no additional context available on a Section callback as it does not represent a
   /// `UIView`, and instead is just a grouping mechanism.
   public typealias CallbackContext = Void
+}
+
+// MARK: Deprecations
+
+extension SectionModel {
+  @available(*, deprecated, renamed: "init(dataID:items:)", message: "SectionModels now require a dataID to make it harder to have sections with duplicated identities")
+  public init(items: [ItemModeling]) {
+    self.items = items
+  }
+
+  @available(*, deprecated, renamed: "init(dataID:items:)", message: "SectionModels now require a dataID to make it harder to have sections with duplicated identities")
+  public init(@ItemModelBuilder items: () -> [ItemModeling]) {
+    self.items = items()
+  }
 }

--- a/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SectionModel/SectionModel.swift
@@ -80,12 +80,20 @@ extension SectionModel: CallbackContextEpoxyModeled {
 // MARK: Deprecations
 
 extension SectionModel {
-  @available(*, deprecated, renamed: "init(dataID:items:)", message: "SectionModels now require a dataID to make it harder to have sections with duplicated identities")
+  @available(
+    *,
+    deprecated,
+    renamed: "init(dataID:items:)",
+    message: "SectionModel requires an explicit dataID")
   public init(items: [ItemModeling]) {
     self.items = items
   }
 
-  @available(*, deprecated, renamed: "init(dataID:items:)", message: "SectionModels now require a dataID to make it harder to have sections with duplicated identities")
+  @available(
+    *,
+    deprecated,
+    renamed: "init(dataID:items:)",
+    message: "SectionModel requires an explicit dataID")
   public init(@ItemModelBuilder items: () -> [ItemModeling]) {
     self.items = items()
   }

--- a/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
+++ b/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
@@ -1,6 +1,7 @@
 //  Created by Laura Skelton on 6/30/17.
 //  Copyright © 2017 Airbnb. All rights reserved.
 
+import EpoxyCore
 import UIKit
 
 /// A subclassable collection view controller that manages its sections declarative via an array of
@@ -25,7 +26,8 @@ open class CollectionViewController: UIViewController {
   ///
   /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
   public convenience init(layout: UICollectionViewLayout, items: [ItemModeling]) {
-    self.init(layout: layout, sections: [SectionModel(items: items)])
+    let section = SectionModel(dataID: DefaultDataID.noneProvided, items: items)
+    self.init(layout: layout, sections: [section])
   }
 
   /// Initializes a collection view controller and configures its collection view with the provided
@@ -109,7 +111,8 @@ open class CollectionViewController: UIViewController {
   ///
   /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
   public func setItems(_ items: [ItemModeling], animated: Bool) {
-    setSections([SectionModel(items: items)], animated: animated)
+    let section = SectionModel(dataID: DefaultDataID.noneProvided, items: items)
+    setSections([section], animated: animated)
   }
 
   // MARK: Private


### PR DESCRIPTION
## Change summary
As-is, the existing initializer makes it too easy to have sections that aren't possible to distinguish from one another, resulting in a runtime warning.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Added a `SectionModel` that took a data ID, verified a warning was produced

## Pull request checklist
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
