### PR TITLE
Adding SetContentProviding to AnyItemModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `Array` and `Optional` expressions to model result builders
 - Added support for `Optional` expressions to `PresentationModel` result builders
+- Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`.
+- Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`.
 
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 

--- a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
@@ -45,6 +45,10 @@ extension AnyItemModel: DidEndDisplayingProviding {}
 
 extension AnyItemModel: DidSelectProviding {}
 
+// MARK: SetContentProviding
+
+extension AnyItemModel: SetContentProviding {}
+
 // MARK: ItemModeling
 
 extension AnyItemModel: ItemModeling {
@@ -68,6 +72,9 @@ extension AnyItemModel: InternalItemModeling {
 
   public func configure(cell: ItemWrapperView, with metadata: ItemCellMetadata) {
     model.configure(cell: cell, with: metadata)
+    if let view = cell.view {
+      setContent?(.init(view: view, metadata: metadata))
+    }
   }
 
   public func setBehavior(cell: ItemWrapperView, with metadata: ItemCellMetadata) {

--- a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
@@ -49,6 +49,14 @@ extension AnyItemModel: DidSelectProviding {}
 
 extension AnyItemModel: SetContentProviding {}
 
+// MARK: DidChangeStateProviding
+
+extension AnyItemModel: DidChangeStateProviding {}
+
+// MARK: SetBehaviorsProviding
+
+extension AnyItemModel: SetBehaviorsProviding {}
+
 // MARK: ItemModeling
 
 extension AnyItemModel: ItemModeling {
@@ -79,10 +87,16 @@ extension AnyItemModel: InternalItemModeling {
 
   public func setBehavior(cell: ItemWrapperView, with metadata: ItemCellMetadata) {
     model.setBehavior(cell: cell, with: metadata)
+    if let view = cell.view {
+      setBehaviors?(.init(view: view, metadata: metadata))
+    }
   }
 
   public func configureStateChange(in cell: ItemWrapperView, with metadata: ItemCellMetadata) {
     model.configureStateChange(in: cell, with: metadata)
+    if let view = cell.view {
+      didChangeState?(.init(view: view, metadata: metadata))
+    }
   }
 
   public func handleDidSelect(_ cell: ItemWrapperView, with metadata: ItemCellMetadata) {

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
@@ -47,6 +47,14 @@ extension AnySupplementaryItemModel: WillDisplayProviding {}
 
 extension AnySupplementaryItemModel: DidEndDisplayingProviding {}
 
+// MARK: SetContentProviding
+
+extension AnySupplementaryItemModel: SetContentProviding {}
+
+// MARK: SetBehaviorsProviding
+
+extension AnySupplementaryItemModel: SetBehaviorsProviding {}
+
 // MARK: SupplementaryItemModeling
 
 extension AnySupplementaryItemModel: SupplementaryItemModeling {
@@ -75,6 +83,9 @@ extension AnySupplementaryItemModel: InternalSupplementaryItemModeling {
     animated: Bool)
   {
     model.configure(reusableView: reusableView, traitCollection: traitCollection, animated: animated)
+    if let view = reusableView.view {
+      setContent?(.init(view: view, traitCollection: traitCollection, animated: animated))
+    }
   }
 
   func handleWillDisplay(
@@ -105,6 +116,9 @@ extension AnySupplementaryItemModel: InternalSupplementaryItemModeling {
     animated: Bool)
   {
     model.setBehavior(reusableView: reusableView, traitCollection: traitCollection, animated: animated)
+    if let view = reusableView.view {
+      setBehaviors?(.init(view: view, traitCollection: traitCollection, animated: animated))
+    }
   }
 }
 

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -411,7 +411,7 @@ final class CollectionViewSpec: QuickSpec {
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
 
             collectionView.setSections([section], animated: false)
-            // // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
+            // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
             collectionView.layoutIfNeeded()
           }
 
@@ -443,7 +443,7 @@ final class CollectionViewSpec: QuickSpec {
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItem])
 
             collectionView.setSections([section], animated: false)
-            // // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
+            // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
             collectionView.layoutIfNeeded()
           }
 

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -288,33 +288,224 @@ final class CollectionViewSpec: QuickSpec {
       }
     }
 
-    describe("setContent") {
-      var didSetContent: [ItemModel<TestView>.CallbackContext]!
-      var erasedItemDidSetContent: [AnyItemModel.CallbackContext]!
+    describe("setBehavior") {
+      var section: SectionModel!
 
-      context("when the content is set") {
+      context("when the behavior is set") {
+        context("ItemModel") {
+          var didSetBehaviors: [ItemModel<TestView>.CallbackContext]!
+          var erasedItemDidSetBehaviors: [AnyItemModel.CallbackContext]!
+          
+          beforeEach {
+            let item = itemModel
+              .setBehaviors {
+                didSetBehaviors.append($0)
+              }
+              .eraseToAnyItemModel()
+              .setBehaviors {
+                erasedItemDidSetBehaviors.append($0)
+              }
+
+            didSetBehaviors = []
+            erasedItemDidSetBehaviors = []
+
+            section = SectionModel(items: [item])
+              .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
+          }
+
+          afterEach {
+            didSetBehaviors = nil
+            erasedItemDidSetBehaviors = nil
+            section = nil
+          }
+
+          context("before its behavior is set") {
+            it("should not call setBehavior") {
+              expect(didSetBehaviors).to(haveCount(0))
+              expect(erasedItemDidSetBehaviors).to(haveCount(0))
+            }
+          }
+
+          context("behavior has been set") {
+            beforeEach {
+              collectionView.setSections([section], animated: false)
+              // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetBehaviors
+              collectionView.layoutIfNeeded()
+            }
+
+            it("should call didSetBehaviors") {
+              expect(didSetBehaviors).to(haveCount(1))
+              expect(erasedItemDidSetBehaviors).to(haveCount(1))
+            }
+          }
+        }
+        context("SupplementaryItemModel") {
+          var didSetBehaviorsSupplementary: [SupplementaryItemModel<TestView>.CallbackContext]!
+          var erasedItemDidSetBehaviorsSupplementary: [AnySupplementaryItemModel.CallbackContext]!
+
+          beforeEach {
+            let supplementaryItem = supplementaryItemModel
+              .setBehaviors {
+                didSetBehaviorsSupplementary.append($0)
+              }
+              .eraseToAnySupplementaryItemModel()
+              .setBehaviors {
+                erasedItemDidSetBehaviorsSupplementary.append($0)
+              }
+
+            didSetBehaviorsSupplementary = []
+            erasedItemDidSetBehaviorsSupplementary = []
+
+            section = SectionModel(items: [itemModel])
+              .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItem])
+          }
+
+          afterEach {
+            didSetBehaviorsSupplementary = nil
+            erasedItemDidSetBehaviorsSupplementary = nil
+            section = nil
+          }
+
+          context("before its behavior is set") {
+            it("should not call setBehavior") {
+              expect(didSetBehaviorsSupplementary).to(haveCount(0))
+              expect(erasedItemDidSetBehaviorsSupplementary).to(haveCount(0))
+            }
+          }
+          context("behavior has been set") {
+            beforeEach {
+              collectionView.setSections([section], animated: false)
+              // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetBehaviors
+              collectionView.layoutIfNeeded()
+            }
+
+            it("should call didSetBehaviors") {
+              expect(didSetBehaviorsSupplementary).to(haveCount(1))
+              expect(erasedItemDidSetBehaviorsSupplementary).to(haveCount(1))
+            }
+          }
+        }
+      }
+    }
+
+    describe("setContent") {
+      context("ItemModel") {
+        var didSetContent: [ItemModel<TestView>.CallbackContext]!
+        var erasedItemDidSetContent: [AnyItemModel.CallbackContext]!
+
+        context("when the content is set") {
+          beforeEach {
+            let item = itemModel
+              .setContent {
+                didSetContent.append($0)
+              }
+              .eraseToAnyItemModel()
+              .setContent {
+                erasedItemDidSetContent.append($0)
+              }
+
+            didSetContent = []
+            erasedItemDidSetContent = []
+
+            let section = SectionModel(items: [item])
+              .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
+
+            collectionView.setSections([section], animated: false)
+            // // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
+            collectionView.layoutIfNeeded()
+          }
+
+          it("should call didSetContent") {
+            expect(didSetContent).to(haveCount(1))
+            expect(erasedItemDidSetContent).to(haveCount(1))
+          }
+        }
+      }
+      context("SupplementaryItemModel") {
+        var didSetContentSupplementary: [SupplementaryItemModel<TestView>.CallbackContext]!
+        var erasedItemDidSetContentSupplementary: [AnySupplementaryItemModel.CallbackContext]!
+
+        context("when the content is set") {
+          beforeEach {
+            let supplementaryItem = supplementaryItemModel
+              .setContent {
+                didSetContentSupplementary.append($0)
+              }
+              .eraseToAnySupplementaryItemModel()
+              .setContent {
+                erasedItemDidSetContentSupplementary.append($0)
+              }
+
+            didSetContentSupplementary = []
+            erasedItemDidSetContentSupplementary = []
+
+            let section = SectionModel(items: [itemModel])
+              .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItem])
+
+            collectionView.setSections([section], animated: false)
+            // // layoutIfNeeded is required to force the epoxy lifecycle and trigger didSetContent
+            collectionView.layoutIfNeeded()
+          }
+
+          it("should call didSetContent") {
+            expect(didSetContentSupplementary).to(haveCount(1))
+            expect(erasedItemDidSetContentSupplementary).to(haveCount(1))
+          }
+        }
+      }
+    }
+
+    describe("didChangeState") {
+      var didChangeState: [ItemModel<TestView>.CallbackContext]!
+      var erasedItemDidChangeState: [AnyItemModel.CallbackContext]!
+      var section: SectionModel!
+
+      context("when the behavior is set") {
         beforeEach {
           let item = itemModel
-            .setContent {
-              didSetContent.append($0)
+            .didChangeState {
+              didChangeState.append($0)
             }
             .eraseToAnyItemModel()
-            .setContent {
-              erasedItemDidSetContent.append($0)
+            .didChangeState {
+              erasedItemDidChangeState.append($0)
             }
 
-          didSetContent = []
-          erasedItemDidSetContent = []
+          didChangeState = []
+          erasedItemDidChangeState = []
 
-          let section = SectionModel(items: [item])
+          section = SectionModel(items: [item])
             .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
-          
           collectionView.setSections([section], animated: false)
+          // Required to prevent a index path out of bounds exception during selection.
+          collectionView.layoutIfNeeded()
         }
 
-        it("should call didSetContent") {
-          expect(didSetContent).to(haveCount(1))
-          expect(erasedItemDidSetContent).to(haveCount(1))
+        afterEach {
+          didChangeState = nil
+          erasedItemDidChangeState = nil
+          section = nil
+        }
+
+        context("before its behavior is set") {
+          it("should not call setBehavior") {
+            expect(didChangeState).to(haveCount(0))
+            expect(erasedItemDidChangeState).to(haveCount(0))
+          }
+        }
+
+        context("behavior has been set") {
+          beforeEach {
+            // didHighlightItemAt is being used to trigger didChangeState
+            collectionView.delegate?.collectionView?(
+              collectionView,
+              didHighlightItemAt: IndexPath(item: 0, section: 0))
+          }
+
+          it("should call didSetBehaviors") {
+            expect(didChangeState).to(haveCount(1))
+            expect(erasedItemDidChangeState).to(haveCount(1))
+          }
         }
       }
     }

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -310,8 +310,6 @@ final class CollectionViewSpec: QuickSpec {
             .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
           
           collectionView.setSections([section], animated: false)
-          // Required to prevent a index path out of bounds exception during selection.
-          collectionView.layoutIfNeeded()
         }
 
         it("should call didSetContent") {

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -288,6 +288,39 @@ final class CollectionViewSpec: QuickSpec {
       }
     }
 
+    describe("did Set Content") {
+      var didSetContent: [ItemModel<TestView>.CallbackContext]!
+      var erasedItemDidSetContent: [AnyItemModel.CallbackContext]!
+
+      context("when the content is set") {
+        beforeEach {
+          let item = itemModel
+            .setContent {
+              didSetContent.append($0)
+            }
+            .eraseToAnyItemModel()
+            .setContent {
+              erasedItemDidSetContent.append($0)
+            }
+
+          didSetContent = []
+          erasedItemDidSetContent = []
+
+          let section = SectionModel(items: [item])
+            .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
+          
+          collectionView.setSections([section], animated: false)
+          // Required to prevent a index path out of bounds exception during selection.
+          collectionView.layoutIfNeeded()
+        }
+
+        it("should call didSetContent") {
+          expect(didSetContent).to(haveCount(1))
+          expect(erasedItemDidSetContent).to(haveCount(1))
+        }
+      }
+    }
+
     describe("item selection") {
       var itemDidSelect: [ItemModel<TestView>.CallbackContext]!
       var erasedItemDidSelect: [AnyItemModel.CallbackContext]!

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -288,7 +288,7 @@ final class CollectionViewSpec: QuickSpec {
       }
     }
 
-    describe("did Set Content") {
+    describe("setContent") {
       var didSetContent: [ItemModel<TestView>.CallbackContext]!
       var erasedItemDidSetContent: [AnyItemModel.CallbackContext]!
 


### PR DESCRIPTION
## Change summary
Adding `SetContentProviding` to `AnyItemModel` to enable use of `adaptiveMarginsOverride` within `AnyItemModel`

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
