### PR TITLE
Make ItemSelectionStyle conform to Hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`.
 - Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`.
 - Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`.
+- Made `ItemSelectionStyle` conform to `Hashable`
 
 ### Fixed
 - Bar installers gracefully handle redundant calls to install/uninstall

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/ItemSelectionStyle.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/ItemSelectionStyle.swift
@@ -6,7 +6,7 @@ import UIKit
 /// The style applied to selected items in a `CollectionView`.
 ///
 /// - SeeAlso: `SelectionStyleProviding`
-public enum ItemSelectionStyle {
+public enum ItemSelectionStyle: Hashable {
   /// No background is drawn behind selected items.
   ///
   /// This case can't be labeled "none" as that is misinterpreted by the compiler as Optional.none


### PR DESCRIPTION
## Change summary
This makes it easier to make a selection style part of a style.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
N/A, conformance is synthesized

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
