### PR TITLE
Expose keyboardContentInsetAdjustment on UIScrollView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `Optional` expressions to `PresentationModel` result builders
 - Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`.
 - Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`.
+- Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`.
 
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 


### PR DESCRIPTION
## Change summary
Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
