### PR TITLE
Gracefully handle redundant calls to install/uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`.
 - Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`.
 
+### Fixed
+- Bar installers gracefully handle redundant calls to install/uninstall
+
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 
 ### Added

--- a/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
@@ -44,10 +44,10 @@ final class BarInstaller<Container: BarContainer> {
   /// Installs the bar stack into the associated view controller.
   ///
   /// Should be called once the view controller loads its view. If this installer has no bar model,
-  /// no view will be added. A view will only be added once a non-nil bar model is set after
-  /// installation or if a bar model was set prior to installation.
+  /// no view will be added. Bar views will only be added once bar models are set after installation
+  /// or if bar models were set prior to installation.
   func install() {
-    installed = true
+    guard !installed else { return }
 
     guard let view = viewController?.viewIfLoaded else {
       EpoxyLogger.shared.assertionFailure(
@@ -56,11 +56,16 @@ final class BarInstaller<Container: BarContainer> {
     }
 
     setBars(bars, animated: false, in: view)
+
+    installed = true
   }
 
   /// Removes the bar stack from the associated view controller.
   func uninstall() {
+    guard installed else { return }
+
     uninstallContainer()
+
     installed = false
   }
 


### PR DESCRIPTION
## Change summary
Ensures that redundant calls to `install` or `uninstall` after either has occurred don't have extra side-effects.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
