### PR TITLE
Gracefully handle styleID mutations after registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bar installers gracefully handle redundant calls to install/uninstall
+- Collection Views more gracefully handle styleID mutations after registration
 
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `Array` and `Optional` expressions to model result builders
 - Added support for `Optional` expressions to `PresentationModel` result builders
-- Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`.
-- Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`.
-- Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`.
+- Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`
+- Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`
+- Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`
 - Made `ItemSelectionStyle` conform to `Hashable`
+- `ReuseIDStore` has a new method to vend a previously registered reuse ID, `registeredReuseID(for:)`
 
 ### Fixed
 - Bar installers gracefully handle redundant calls to install/uninstall
-- Collection Views more gracefully handle styleID mutations after registration
+- `CollectionView` more gracefully handles styleID mutations after registration
+
+### Changed
+- `ReuseIDStore.registerReuseID(for:)` has been renamed to `ReuseIDStore.reuseID(byRegistering:)`
 
 ## [0.2.0](https://github.com/airbnb/epoxy-ios/compare/0.1.0...0.2.0) - 2021-03-16
 

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -190,7 +190,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
       let item = data?.item(at: indexPath),
       let reuseID = reuseIDStore.registeredReuseID(for: item.viewDifferentiator)
     else {
-      // The `item(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
+      // The `item(…)` or `registeredReuseID(…)` methods will assert in this scenario.
       return UICollectionViewCell()
     }
 
@@ -215,7 +215,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
       let item = data?.supplementaryItem(ofKind: kind, at: indexPath),
       let reuseID = reuseIDStore.registeredReuseID(for: item.viewDifferentiator)
     else {
-      // The `supplementaryItem(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
+      // The `supplementaryItem(…)` or `registeredReuseID(…)` methods will assert in this scenario.
       return UICollectionReusableView()
     }
 

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -137,7 +137,7 @@ final class CollectionViewDataSource: NSObject {
       return
     }
     for viewDifferentiator in newViewDifferentiators {
-      let reuseID = reuseIDStore.reuseID(for: viewDifferentiator)
+      let reuseID = reuseIDStore.registerReuseID(for: viewDifferentiator)
       collectionView.register(cellReuseID: reuseID)
     }
   }
@@ -152,7 +152,7 @@ final class CollectionViewDataSource: NSObject {
       return
     }
     for viewDifferentiator in newViewDifferentiators {
-      let reuseID = reuseIDStore.reuseID(for: viewDifferentiator)
+      let reuseID = reuseIDStore.registerReuseID(for: viewDifferentiator)
       collectionView.register(
         supplementaryViewReuseID: reuseID,
         forKind: elementKind)
@@ -186,15 +186,15 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
     cellForItemAt indexPath: IndexPath)
     -> UICollectionViewCell
   {
-    guard let item = data?.item(at: indexPath) else {
-      // The `item(…)` method asserts in this scenario.
+    guard
+      let item = data?.item(at: indexPath),
+      let reuseID = reuseIDStore.dequeueReuseID(for: item.viewDifferentiator)
+    else {
+      // The `item(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
       return UICollectionViewCell()
     }
 
-    let reuseID = reuseIDStore.reuseID(for: item.viewDifferentiator)
-    let cell = collectionView.dequeueReusableCell(
-      withReuseIdentifier: reuseID,
-      for: indexPath)
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseID, for: indexPath)
 
     if let cell = cell as? CollectionViewCell {
       self.collectionView?.configure(cell: cell, with: item, animated: false)
@@ -211,12 +211,14 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
     at indexPath: IndexPath)
     -> UICollectionReusableView
   {
-    guard let model = data?.supplementaryItem(ofKind: kind, at: indexPath) else {
-      // The `supplementaryItem(…)` method asserts in this scenario.
+    guard
+      let item = data?.supplementaryItem(ofKind: kind, at: indexPath),
+      let reuseID = reuseIDStore.dequeueReuseID(for: item.viewDifferentiator)
+    else {
+      // The `supplementaryItem(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
       return UICollectionReusableView()
     }
 
-    let reuseID = reuseIDStore.reuseID(for: model.viewDifferentiator)
     let supplementaryView = collectionView.dequeueReusableSupplementaryView(
       ofKind: kind,
       withReuseIdentifier: reuseID,
@@ -225,7 +227,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
     if let supplementaryView = supplementaryView as? CollectionViewReusableView {
       self.collectionView?.configure(
         supplementaryView: supplementaryView,
-        with: model,
+        with: item,
         animated: false)
     } else {
       EpoxyLogger.shared.assertionFailure(

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -137,7 +137,7 @@ final class CollectionViewDataSource: NSObject {
       return
     }
     for viewDifferentiator in newViewDifferentiators {
-      let reuseID = reuseIDStore.registerReuseID(for: viewDifferentiator)
+      let reuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator)
       collectionView.register(cellReuseID: reuseID)
     }
   }
@@ -152,7 +152,7 @@ final class CollectionViewDataSource: NSObject {
       return
     }
     for viewDifferentiator in newViewDifferentiators {
-      let reuseID = reuseIDStore.registerReuseID(for: viewDifferentiator)
+      let reuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator)
       collectionView.register(
         supplementaryViewReuseID: reuseID,
         forKind: elementKind)
@@ -188,7 +188,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
   {
     guard
       let item = data?.item(at: indexPath),
-      let reuseID = reuseIDStore.dequeueReuseID(for: item.viewDifferentiator)
+      let reuseID = reuseIDStore.registeredReuseID(for: item.viewDifferentiator)
     else {
       // The `item(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
       return UICollectionViewCell()
@@ -213,7 +213,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
   {
     guard
       let item = data?.supplementaryItem(ofKind: kind, at: indexPath),
-      let reuseID = reuseIDStore.dequeueReuseID(for: item.viewDifferentiator)
+      let reuseID = reuseIDStore.registeredReuseID(for: item.viewDifferentiator)
     else {
       // The `supplementaryItem(…)` or `dequeueReuseID(…)` methods will assert in this scenario.
       return UICollectionReusableView()

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
@@ -23,9 +23,10 @@ public final class ReuseIDStore {
 
   // MARK: Public
 
-  /// Vends a new reuse identifier string for the given `ViewDifferentiator`, generating a new reuse
-  /// identifier whenever a new `viewDifferentiator` is encountered as determined by its equality.
-  public func registerReuseID(for viewDifferentiator: ViewDifferentiator) -> String {
+  /// Vends a new reuse identifier string for the given `ViewDifferentiator` by generating a
+  /// registering new reuse identifier whenever a new `ViewDifferentiator` is encountered as
+  /// determined by its equality.
+  public func reuseID(byRegistering viewDifferentiator: ViewDifferentiator) -> String {
     if let existingReuseID = reuseIDsForViewDifferentiators[viewDifferentiator] {
       return existingReuseID
     }
@@ -39,21 +40,19 @@ public final class ReuseIDStore {
     return reuseID
   }
 
-  /// Attempts to dequeue a reuse identifier string for the given `ViewDifferentiator`.
-  public func dequeueReuseID(for viewDifferentiator: ViewDifferentiator) -> String? {
+  /// Attempts to retrieve a previously registered reuse identifier string for the given
+  /// `ViewDifferentiator`, else asserts and attempts to return a fallback reuse ID for a view
+  /// of the same type if one could not be found, and otherwise returns nil.
+  public func registeredReuseID(for viewDifferentiator: ViewDifferentiator) -> String? {
     if let existingReuseID = reuseIDsForViewDifferentiators[viewDifferentiator] {
       return existingReuseID
     }
 
-    // We're attempting to dequeue a reuse ID for a `ViewDifferentiator` that doesn't exist in . This
-    // is probably due to an `ViewDifferentiator.styleID` instance that an has unstable hash value,
-    // e.g. a `Hashable` `class` that is mutated _after_ being set on a component, giving it a new
-    // hash value.
     EpoxyLogger.shared.assertionFailure(
       """
       Unable to dequeue reuse ID for \(viewDifferentiator.viewTypeDescription) styleID \
       \(viewDifferentiator.styleID?.base as Any) as it has an unstable implementation of \
-      `Hashable`. This is likely due to an `styleID` instance that an has unstable hash value, \
+      `Hashable`. This is likely due to a `styleID` instance that an has unstable hash value, \
       e.g. a `Hashable` `class` that is mutated _after_ being set on a view, causing it to be \
       unequal to the `styleID` that was originally registered. Attempting to dequeue another view \
       of the same type. This is programmer error.

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
@@ -23,9 +23,9 @@ public final class ReuseIDStore {
 
   // MARK: Public
 
-  /// Vends a new reuse identifier string for the given `ViewDifferentiator` by generating a
-  /// registering new reuse identifier whenever a new `ViewDifferentiator` is encountered as
-  /// determined by its equality.
+  /// Generates and returns a new reuse identifier if the given view differentiator has not been
+  /// previously registered as determined by its equality, else returns its existing reuse
+  /// identifier.
   public func reuseID(byRegistering viewDifferentiator: ViewDifferentiator) -> String {
     if let existingReuseID = reuseIDsForViewDifferentiators[viewDifferentiator] {
       return existingReuseID
@@ -40,9 +40,9 @@ public final class ReuseIDStore {
     return reuseID
   }
 
-  /// Attempts to retrieve a previously registered reuse identifier string for the given
-  /// `ViewDifferentiator`, else asserts and attempts to return a fallback reuse ID for a view
-  /// of the same type if one could not be found, and otherwise returns nil.
+  /// Attempts to retrieve a previously generated reuse identifier for the given view differentiator
+  /// if it has been previously registered, else asserts and attempts to return a fallback reuse
+  /// identifier for a view of the same type if one could not be found, otherwise returns `nil`.
   public func registeredReuseID(for viewDifferentiator: ViewDifferentiator) -> String? {
     if let existingReuseID = reuseIDsForViewDifferentiators[viewDifferentiator] {
       return existingReuseID

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/ReuseIDStore.swift
@@ -50,12 +50,12 @@ public final class ReuseIDStore {
 
     EpoxyLogger.shared.assertionFailure(
       """
-      Unable to dequeue reuse ID for \(viewDifferentiator.viewTypeDescription) styleID \
-      \(viewDifferentiator.styleID?.base as Any) as it has an unstable implementation of \
-      `Hashable`. This is likely due to a `styleID` instance that an has unstable hash value, \
-      e.g. a `Hashable` `class` that is mutated _after_ being set on a view, causing it to be \
-      unequal to the `styleID` that was originally registered. Attempting to dequeue another view \
-      of the same type. This is programmer error.
+      Unable to locate a reuse ID for \(viewDifferentiator.viewTypeDescription) with styleID \
+      \(viewDifferentiator.styleID?.base as Any) as it has an unstable implementation of Hashable. \
+      This is likely due to a styleID type with unstable comparability, e.g. a Style class that is \
+      mutated _after_ being set on a view, causing it to be unequal to the styleID that was \
+      originally registered. Attempting to dequeue another view of the same type. This is \
+      programmer error.
       """)
 
     return reuseIDsForViewDifferentiators

--- a/Sources/EpoxyCore/Model/Providers/ViewDifferentiatorProviding.swift
+++ b/Sources/EpoxyCore/Model/Providers/ViewDifferentiatorProviding.swift
@@ -30,4 +30,5 @@ public struct ViewDifferentiator: Hashable {
 
   public var viewTypeDescription: String
   public var styleID: AnyHashable?
+
 }

--- a/Tests/EpoxyTests/CollectionViewTests/ReuseIDStoreTests.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/ReuseIDStoreTests.swift
@@ -30,84 +30,84 @@ final class ReuseIDStoreTests: XCTestCase {
 
   // MARK: Tests
 
-  func test_registerReuseID_withSameViewTypeSameStyleID_returnSameReuseID() {
+  func test_reuseIDByRegistering_withSameViewTypeSameStyleID_returnSameReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
-    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator2)
     XCTAssertEqual(firstReuseID, secondReuseID)
   }
 
-  func test_registerReuseID_withDifferentViewTypeSameStyleID_returnDifferentReuseID() {
+  func test_reuseIDByRegistering_withDifferentViewTypeSameStyleID_returnDifferentReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MySecondView.self,
       styleID: "red")
-    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator2)
     XCTAssertNotEqual(firstReuseID, secondReuseID)
   }
 
-  func test_registerReuseID_withSameViewTypeDifferentStyleID_returnDifferentReuseID() {
+  func test_reuseIDByRegistering_withSameViewTypeDifferentStyleID_returnDifferentReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "blue")
-    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.reuseID(byRegistering: viewDifferentiator2)
     XCTAssertNotEqual(firstReuseID, secondReuseID)
   }
 
-  func test_dequeueReuseID_withSameViewTypeSameStyleID_returnSameReuseID() {
+  func test_registeredReuseIDFor_withSameViewTypeSameStyleID_returnSameReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
-    let registerReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let dequeueReuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator2)
-    XCTAssertEqual(registerReuseID, dequeueReuseID)
+    let reuseIDByRegistering = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let registeredReuseIDFor = reuseIDStore.registeredReuseID(for: viewDifferentiator2)
+    XCTAssertEqual(reuseIDByRegistering, registeredReuseIDFor)
   }
 
-  func test_dequeueReuseID_whenNotRegistered_returnsNil() {
+  func test_registeredReuseIDFor_whenNotRegistered_returnsNil() {
     let viewDifferentiator = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
-    let reuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator)
+    let reuseID = reuseIDStore.registeredReuseID(for: viewDifferentiator)
     XCTAssertNil(reuseID)
   }
 
-  func test_dequeueReuseID_whenNotRegistered_asserts() {
+  func test_registeredReuseIDFor_whenNotRegistered_asserts() {
     let viewDifferentiator = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     XCTAssertTrue(assertionFailures.isEmpty)
-    _ = reuseIDStore.dequeueReuseID(for: viewDifferentiator)
+    _ = reuseIDStore.registeredReuseID(for: viewDifferentiator)
     XCTAssertFalse(assertionFailures.isEmpty)
   }
 
-  func test_dequeueReuseID_withSameViewTypeDifferentStyleID_returnsFallbackReuseID() {
+  func test_registeredReuseIDFor_withSameViewTypeDifferentStyleID_returnsFallbackReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "blue")
-    let registerReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let dequeueReuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator2)
-    XCTAssertEqual(registerReuseID, dequeueReuseID)
+    let reuseIDByRegistering = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let registeredReuseIDFor = reuseIDStore.registeredReuseID(for: viewDifferentiator2)
+    XCTAssertEqual(reuseIDByRegistering, registeredReuseIDFor)
   }
 
-  func test_dequeueReuseID_afterSubsequentRegisterWithDifferentStyleID_returnsSameFallbackReuseID() {
+  func test_registeredReuseIDFor_afterSubsequentRegisterWithDifferentStyleID_returnsSameFallbackReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
@@ -117,13 +117,13 @@ final class ReuseIDStoreTests: XCTestCase {
     let viewDifferentiator3 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "blue")
-    _ = reuseIDStore.registerReuseID(for: viewDifferentiator1)
-    let dequeueReuseID1 = reuseIDStore.dequeueReuseID(for: viewDifferentiator3)
+    _ = reuseIDStore.reuseID(byRegistering: viewDifferentiator1)
+    let registeredReuseIDFor1 = reuseIDStore.registeredReuseID(for: viewDifferentiator3)
 
-    _ = reuseIDStore.registerReuseID(for: viewDifferentiator2)
-    let dequeueReuseID2 = reuseIDStore.dequeueReuseID(for: viewDifferentiator3)
+    _ = reuseIDStore.reuseID(byRegistering: viewDifferentiator2)
+    let registeredReuseIDFor2 = reuseIDStore.registeredReuseID(for: viewDifferentiator3)
 
-    XCTAssertEqual(dequeueReuseID1, dequeueReuseID2)
+    XCTAssertEqual(registeredReuseIDFor1, registeredReuseIDFor2)
   }
 
   // MARK: Private

--- a/Tests/EpoxyTests/CollectionViewTests/ReuseIDStoreTests.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/ReuseIDStoreTests.swift
@@ -15,53 +15,121 @@ final class ReuseIDStoreTests: XCTestCase {
 
   override func setUp() {
     reuseIDStore = ReuseIDStore()
+    assertionFailures = []
+    EpoxyLogger.shared = .init(
+      assert: { (_, _, _, _) in },
+      assertionFailure: { [weak self] (message, fileID, line) in
+        self?.assertionFailures.append((message(), fileID, line))
+      }, warn: { (_, _, _) in })
   }
 
   override func tearDown() {
     reuseIDStore = nil
+    EpoxyLogger.shared = EpoxyLogger()
   }
 
   // MARK: Tests
 
-  func testSameViewTypeSameStyleIDReturnSameReuseID() {
+  func test_registerReuseID_withSameViewTypeSameStyleID_returnSameReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
-    let firstReuseID = reuseIDStore.reuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.reuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
     XCTAssertEqual(firstReuseID, secondReuseID)
   }
 
-  func testDifferentViewTypeSameStyleIDReturnDifferentReuseID() {
+  func test_registerReuseID_withDifferentViewTypeSameStyleID_returnDifferentReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MySecondView.self,
       styleID: "red")
-    let firstReuseID = reuseIDStore.reuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.reuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
     XCTAssertNotEqual(firstReuseID, secondReuseID)
   }
 
-  func testSameViewTypeDifferentStyleIDReturnDifferentReuseID() {
+  func test_registerReuseID_withSameViewTypeDifferentStyleID_returnDifferentReuseID() {
     let viewDifferentiator1 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "red")
     let viewDifferentiator2 = ViewDifferentiator(
       viewType: MyFirstView.self,
       styleID: "blue")
-    let firstReuseID = reuseIDStore.reuseID(for: viewDifferentiator1)
-    let secondReuseID = reuseIDStore.reuseID(for: viewDifferentiator2)
+    let firstReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let secondReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator2)
     XCTAssertNotEqual(firstReuseID, secondReuseID)
+  }
+
+  func test_dequeueReuseID_withSameViewTypeSameStyleID_returnSameReuseID() {
+    let viewDifferentiator1 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    let viewDifferentiator2 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    let registerReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let dequeueReuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator2)
+    XCTAssertEqual(registerReuseID, dequeueReuseID)
+  }
+
+  func test_dequeueReuseID_whenNotRegistered_returnsNil() {
+    let viewDifferentiator = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    let reuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator)
+    XCTAssertNil(reuseID)
+  }
+
+  func test_dequeueReuseID_whenNotRegistered_asserts() {
+    let viewDifferentiator = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    XCTAssertTrue(assertionFailures.isEmpty)
+    _ = reuseIDStore.dequeueReuseID(for: viewDifferentiator)
+    XCTAssertFalse(assertionFailures.isEmpty)
+  }
+
+  func test_dequeueReuseID_withSameViewTypeDifferentStyleID_returnsFallbackReuseID() {
+    let viewDifferentiator1 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    let viewDifferentiator2 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "blue")
+    let registerReuseID = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let dequeueReuseID = reuseIDStore.dequeueReuseID(for: viewDifferentiator2)
+    XCTAssertEqual(registerReuseID, dequeueReuseID)
+  }
+
+  func test_dequeueReuseID_afterSubsequentRegisterWithDifferentStyleID_returnsSameFallbackReuseID() {
+    let viewDifferentiator1 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "red")
+    let viewDifferentiator2 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "green")
+    let viewDifferentiator3 = ViewDifferentiator(
+      viewType: MyFirstView.self,
+      styleID: "blue")
+    _ = reuseIDStore.registerReuseID(for: viewDifferentiator1)
+    let dequeueReuseID1 = reuseIDStore.dequeueReuseID(for: viewDifferentiator3)
+
+    _ = reuseIDStore.registerReuseID(for: viewDifferentiator2)
+    let dequeueReuseID2 = reuseIDStore.dequeueReuseID(for: viewDifferentiator3)
+
+    XCTAssertEqual(dequeueReuseID1, dequeueReuseID2)
   }
 
   // MARK: Private
 
   private var reuseIDStore: ReuseIDStore!
+  private var assertionFailures: [(String, StaticString, UInt)]!
 }
 
 // MARK: - MyFirstView


### PR DESCRIPTION
## Change summary
Currently, if a `styleID` is mutated after it is set on a collection view, it may result in a crash since we'll be attempting to dequeue a cell that wasn't registered. As such, we do two things to attempt to handle this gracefully:
- We assert in the `ReuseIDStore` in a new dequeue method, and then return a fallback reuse ID of the same component.
- Otherwise, we return an empty `UICollectionViewCell()`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
