### PR TITLE
Make model type erasers conform to StyleIDProviding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `Array` and `Optional` expressions to model result builders
 - Added support for `Optional` expressions to `PresentationModel` result builders
-- Made `AnyItemModel` conform to `DidChangeStateProviding`, `DidChangeStateProviding` and `SetBehaviorsProviding`
-- Made `AnySupplementaryItemModel` conform to `DidChangeStateProviding`, and `SetBehaviorsProviding`
+- Made `AnyItemModel` and `AnySupplementaryItemModel` conform to `DidChangeStateProviding`,
+  `DidChangeStateProviding` and `SetBehaviorsProviding`
+- Made `AnyItemModel`, `AnySupplementaryItemModel`, and `AnyBarModel` conform to `StyleIDProviding`
 - Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`
 - Made `ItemSelectionStyle` conform to `Hashable`
 - `ReuseIDStore` has a new method to vend a previously registered reuse ID, `registeredReuseID(for:)`

--- a/Sources/EpoxyBars/BarModel/AnyBarModel.swift
+++ b/Sources/EpoxyBars/BarModel/AnyBarModel.swift
@@ -39,6 +39,10 @@ extension AnyBarModel: BarModeling {
 
 extension AnyBarModel: DataIDProviding {}
 
+// MARK: StyleIDProviding
+
+extension AnyBarModel: StyleIDProviding {}
+
 // MARK: Diffable
 
 extension AnyBarModel: Diffable {

--- a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
@@ -57,6 +57,10 @@ extension AnyItemModel: DidChangeStateProviding {}
 
 extension AnyItemModel: SetBehaviorsProviding {}
 
+// MARK: StyleIDProviding
+
+extension AnyItemModel: StyleIDProviding {}
+
 // MARK: ItemModeling
 
 extension AnyItemModel: ItemModeling {

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
@@ -55,6 +55,10 @@ extension AnySupplementaryItemModel: SetContentProviding {}
 
 extension AnySupplementaryItemModel: SetBehaviorsProviding {}
 
+// MARK: StyleIDProviding
+
+extension AnySupplementaryItemModel: StyleIDProviding {}
+
 // MARK: SupplementaryItemModeling
 
 extension AnySupplementaryItemModel: SupplementaryItemModeling {


### PR DESCRIPTION
## Change summary
As titled. This allows us to write more generic code on these type-erased models.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
