### PR TITLE
Add case with TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.3.0...HEAD)
+### Added
+- Added an example with text field to show how can we use `avoidsKeyboard` feature
 
 ## [0.3.0](https://github.com/airbnb/epoxy-ios/compare/0.2.0...0.3.0) - 2021-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.3.0...HEAD)
+
 ### Added
 - Added an example with text field to show how can we use `avoidsKeyboard` feature
 

--- a/Example/EpoxyExample.xcodeproj/project.pbxproj
+++ b/Example/EpoxyExample.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		25FEB79225AE431100F8EFBD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FEB79125AE431100F8EFBD /* MainViewController.swift */; };
 		2E8B007623F47E7E00D82A31 /* CustomSizingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8B007523F47E7E00D82A31 /* CustomSizingView.swift */; };
 		2E8B007823F4800000D82A31 /* CustomSelfSizingContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8B007723F4800000D82A31 /* CustomSelfSizingContentViewController.swift */; };
+		A5AD02A72637CBF9007261BC /* TextFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AD02A62637CBF9007261BC /* TextFieldRow.swift */; };
+		A5AD02AA2637CE5E007261BC /* TextFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AD02A92637CE5E007261BC /* TextFieldViewController.swift */; };
 		A61AFF592602B86E005356A8 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61AFF582602B86E005356A8 /* Example.swift */; };
 		A61AFF5C2602B8D7005356A8 /* ReadmeExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61AFF5B2602B8D7005356A8 /* ReadmeExample.swift */; };
 		A61AFF5F2602B99E005356A8 /* TapMeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61AFF5E2602B99E005356A8 /* TapMeViewController.swift */; };
@@ -56,6 +58,8 @@
 		25FEB79125AE431100F8EFBD /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		2E8B007523F47E7E00D82A31 /* CustomSizingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSizingView.swift; sourceTree = "<group>"; };
 		2E8B007723F4800000D82A31 /* CustomSelfSizingContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSelfSizingContentViewController.swift; sourceTree = "<group>"; };
+		A5AD02A62637CBF9007261BC /* TextFieldRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldRow.swift; sourceTree = "<group>"; };
+		A5AD02A92637CE5E007261BC /* TextFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldViewController.swift; sourceTree = "<group>"; };
 		A61AFF582602B86E005356A8 /* Example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example.swift; sourceTree = "<group>"; };
 		A61AFF5B2602B8D7005356A8 /* ReadmeExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadmeExample.swift; sourceTree = "<group>"; };
 		A61AFF5E2602B99E005356A8 /* TapMeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapMeViewController.swift; sourceTree = "<group>"; };
@@ -136,6 +140,7 @@
 				25FEB79125AE431100F8EFBD /* MainViewController.swift */,
 				2518441825B8E35A000B801F /* FlowLayoutViewController.swift */,
 				A667554325D3028D00AC4FC8 /* CardStackViewController.swift */,
+				A5AD02A92637CE5E007261BC /* TextFieldViewController.swift */,
 				A61AFF612602BA20005356A8 /* Helpers */,
 			);
 			path = ViewControllers;
@@ -145,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				A6F0928A25B9E983007D902B /* TextRow.swift */,
+				A5AD02A62637CBF9007261BC /* TextFieldRow.swift */,
 				2E8B007523F47E7E00D82A31 /* CustomSizingView.swift */,
 				25B6766125AE898B00C00B20 /* ImageRow.swift */,
 				25B6766725AFA67100C00B20 /* ButtonRow.swift */,
@@ -285,6 +291,7 @@
 			files = (
 				A633B24625B6507A0095E464 /* ImageMarquee.swift in Sources */,
 				25627B95232ABF0F00D7327A /* CompositionalLayoutViewController.swift in Sources */,
+				A5AD02A72637CBF9007261BC /* TextFieldRow.swift in Sources */,
 				BACF3E8C23DBB8DC0001CCD1 /* ShuffleViewController.swift in Sources */,
 				25627B93232ABF0F00D7327A /* AppDelegate.swift in Sources */,
 				25B6766825AFA67100C00B20 /* ButtonRow.swift in Sources */,
@@ -310,6 +317,7 @@
 				2518441925B8E35A000B801F /* FlowLayoutViewController.swift in Sources */,
 				259863A225AE47710065024B /* UICollectionViewCompositionalLayout+List.swift in Sources */,
 				A667554125D2FEC400AC4FC8 /* CardContainer.swift in Sources */,
+				A5AD02AA2637CE5E007261BC /* TextFieldViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/EpoxyExample/Data/Example.swift
+++ b/Example/EpoxyExample/Data/Example.swift
@@ -52,7 +52,7 @@ enum Example: CaseIterable {
     case .cardStack:
       return "A CollectionView with BarStackView items that have a card drawn around each stack"
     case .textField:
-      return "An example that combines collections, bars, and text field"
+      return "An example that combines collections, bars, and text field with keyboard avoidance"
     }
   }
 }

--- a/Example/EpoxyExample/Data/Example.swift
+++ b/Example/EpoxyExample/Data/Example.swift
@@ -10,6 +10,7 @@ enum Example: CaseIterable {
   case flowLayout
   case shuffle
   case customSelfSizing
+  case textField
 
   // MARK: Internal
 
@@ -29,6 +30,8 @@ enum Example: CaseIterable {
       return "Flow Layout demo"
     case .cardStack:
       return "Card Stack"
+    case .textField:
+      return "Text Field"
     }
   }
 
@@ -48,6 +51,8 @@ enum Example: CaseIterable {
       return "A CollectionView with a UICollectionViewFlowLayout"
     case .cardStack:
       return "A CollectionView with BarStackView items that have a card drawn around each stack"
+    case .textField:
+      return "An example that combines collections, bars, and text field"
     }
   }
 }

--- a/Example/EpoxyExample/ViewControllers/MainViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/MainViewController.swift
@@ -96,6 +96,8 @@ final class MainViewController: NavigationController {
       viewController = FlowLayoutViewController()
     case .cardStack:
       viewController = CardStackViewController()
+    case .textField:
+      viewController = TextFieldViewController()
     }
     viewController.title = example.title
     return viewController

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -42,7 +42,7 @@ final class TextFieldViewController: CollectionViewController {
   private var buttonRowBar: BarModeling {
     ButtonRow.barModel(
       dataID: DataID.button,
-      content: .init(text: "Buy now"),
+      content: .init(text: "Submit"),
       behaviors: .init(didTap: { [weak self] in
         self?.view.endEditing(true)
     }))

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -35,8 +35,7 @@ final class TextFieldViewController: CollectionViewController {
   private var textFieldRowItem: ItemModeling {
     TextFieldRow.itemModel(
       dataID: DataID.username,
-      content: .init(
-        placeholder: "Username"),
+      content: .init(placeholder: "Username"),
       style: .base)
   }
 

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -47,5 +47,4 @@ final class TextFieldViewController: CollectionViewController {
         self?.view.endEditing(true)
       }))
   }
-
 }

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -1,0 +1,52 @@
+// Created by oleksandr_zarochintsev on 4/26/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Epoxy
+import UIKit
+
+final class TextFieldViewController: CollectionViewController {
+
+  // MARK: Lifecycle
+
+  init() {
+    super.init(layout: UICollectionViewCompositionalLayout.listNoDividers)
+    setSections([.init(items: [textFieldRowItem])], animated: true)
+  }
+
+  // MARK: Internal
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    bottomBarInstaller.install()
+  }
+
+  // MARK: Private
+
+  private enum DataID {
+    case username
+    case button
+  }
+
+  private lazy var bottomBarInstaller = BottomBarInstaller(
+    viewController: self,
+    avoidsKeyboard: true,
+    bars: [buttonRowBar])
+
+  private var textFieldRowItem: ItemModeling {
+    TextFieldRow.itemModel(
+      dataID: DataID.username,
+      content: .init(
+        placeholder: "Username"),
+      style: .base)
+  }
+
+  private var buttonRowBar: BarModeling {
+    ButtonRow.barModel(
+      dataID: DataID.button,
+      content: .init(text: "Buy now"),
+      behaviors: .init(didTap: { [weak self] in
+        self?.view.endEditing(true)
+    }))
+  }
+
+}

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -45,7 +45,7 @@ final class TextFieldViewController: CollectionViewController {
       content: .init(text: "Submit"),
       behaviors: .init(didTap: { [weak self] in
         self?.view.endEditing(true)
-    }))
+      }))
   }
 
 }

--- a/Example/EpoxyExample/Views/TextFieldRow.swift
+++ b/Example/EpoxyExample/Views/TextFieldRow.swift
@@ -1,0 +1,79 @@
+// Created by oleksandr_zarochintsev on 4/26/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Epoxy
+import UIKit
+
+final class TextFieldRow: UIView, EpoxyableView {
+
+  // MARK: Lifecycle
+
+  init(style: Style) {
+    self.style = style
+    super.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+    setUpViews()
+    setUpConstraints()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  enum Style {
+    case base
+  }
+
+  struct Content: Equatable {
+    var text: String?
+    var placeholder: String?
+  }
+
+  func setContent(_ content: Content, animated: Bool) {
+    text = content.text
+    placeholder = content.placeholder
+  }
+
+  // MARK: Private
+
+  private let style: Style
+  private let textField = UITextField()
+
+  private var text: String? {
+    get { textField.text }
+    set {
+      guard textField.text != newValue else { return }
+      textField.text = newValue
+    }
+  }
+
+  private var placeholder: String? {
+    get { textField.placeholder }
+    set {
+      guard textField.placeholder != newValue else { return }
+      textField.placeholder = newValue
+    }
+  }
+
+  private func setUpViews() {
+    setUpTextField()
+  }
+
+  private func setUpTextField() {
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.borderStyle = .roundedRect
+    addSubview(textField)
+  }
+
+  private func setUpConstraints() {
+    NSLayoutConstraint.activate([
+      textField.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+      textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+      textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+    ])
+  }
+  
+}

--- a/Example/EpoxyExample/Views/TextFieldRow.swift
+++ b/Example/EpoxyExample/Views/TextFieldRow.swift
@@ -75,5 +75,4 @@ final class TextFieldRow: UIView, EpoxyableView {
       textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
     ])
   }
-  
 }

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ class CounterViewController: CollectionViewController {
   }
 
   var count = 0 {
-    didSet { setItems(items, animated: true) }
+    didSet {
+      setItems(items, animated: true)
+    }
   }
 
   @ItemModelBuilder
@@ -226,7 +228,9 @@ class FormNavigationController: NavigationController {
   }
 
   var showStep2 = false {
-    didSet { setStack(stack, animated: true) }
+    didSet {
+      setStack(stack, animated: true)
+    }
   }
 
   @NavigationModelBuilder
@@ -287,7 +291,9 @@ class PresentationViewController: UIViewController {
   }
 
   var showDetail = true {
-    didSet { setPresentation(presentation, animated: true) }
+    didSet {
+      setPresentation(presentation, animated: true)
+    }
   }
 
   @PresentationModelBuilder


### PR DESCRIPTION
## Change summary
👋 Airbnb Team, I added case with text field, I would like to show how can we use `avoidsKeyboard` feature, I did not find it in examples.

### Screenshots
Main | Base | Keyboard
------- | ------- | -------
<img width="320" alt="Screen Shot 2021-04-26 at 10 14 24 PM" src="https://user-images.githubusercontent.com/5650844/116188781-d31f6c80-a6dc-11eb-9f99-716afcd1bded.png"> | <img width="320" alt="Screen Shot 2021-04-26 at 10 14 26 PM" src="https://user-images.githubusercontent.com/5650844/116188788-d4509980-a6dc-11eb-8436-b8a0fb9b2071.png"> | <img width="320" alt="Screen Shot 2021-04-26 at 10 14 29 PM" src="https://user-images.githubusercontent.com/5650844/116188791-d581c680-a6dc-11eb-8d17-a88fe7c0f8b0.png">

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [x] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
