### PR TITLE
Add update strategy to CollectionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.3.0...HEAD)
 
+### Added
+- Added an `UpdateStrategy` to `CollectionView` to allow specifying that it should update using non-
+  animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
+  `reloadData()`.
+
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 
 ### Added
 - Added an example with text field to show how can we use `avoidsKeyboard` feature
-- Add EpoxyLayoutGroups, a delcarative API for creating components
+- Add EpoxyLayoutGroups, a declarative API for creating components
 
 ### Fixed
 - `AnyItemModel` is selectable when there are no `DidSelect` callbacks on the underlying model
@@ -23,9 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `AnyItemModel` and `AnySupplementaryItemModel` conform to `DidChangeStateProviding`,
   `DidChangeStateProviding` and `SetBehaviorsProviding`
 - Made `AnyItemModel`, `AnySupplementaryItemModel`, and `AnyBarModel` conform to `StyleIDProviding`
-- Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a `KeyboardPositionWatcher`
+- Adds a `keyboardContentInsetAdjustment` property to `UIScrollView` with the amount that the that
+  its `contentInset.bottom` has been adjusted to accommodate for the keyboard by a
+  `KeyboardPositionWatcher`
 - Made `ItemSelectionStyle` conform to `Hashable`
-- `ReuseIDStore` has a new method to vend a previously registered reuse ID, `registeredReuseID(for:)`
+- `ReuseIDStore` has a new method to vend a previously registered reuse ID,
+  `registeredReuseID(for:)`
 
 ### Fixed
 - Bar installers gracefully handle redundant calls to install/uninstall

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -74,6 +74,8 @@ open class CollectionView: UICollectionView {
     /// `reloadData` ourselves, and instead, use batch updates for all content updates.
     case reloadData
 
+    // MARK: Internal
+
     /// Whether this update is animated.
     var animated: Bool {
       switch self {

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -67,11 +67,11 @@ open class CollectionView: UICollectionView {
     /// More performant than `reloadData`, as it does not recreate and reconfigure all visible
     /// cells.
     case nonanimatedBatchUpdates
-    /// Calls `reloadData`, resulting in a non-animated update that recreates and reconfigures all
-    /// visible cells.
+    /// Performs non-animated updates by calling `reloadData()`, which recreates and reconfigures
+    /// all visible cells.
     ///
-    /// Visible cells will be recreated. UIKit engineers have suggested that we should never call
-    /// `reloadData` ourselves, and instead, use batch updates for all content updates.
+    /// UIKit engineers have suggested that we should never need to call `reloadData` on updates,
+    /// and instead just use batch updates for all content updates.
     case reloadData
 
     // MARK: Internal

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -17,7 +17,7 @@ open class CollectionView: UICollectionView {
     layout: UICollectionViewLayout,
     configuration: CollectionViewConfiguration = .shared)
   {
-    epoxyDataSource = CollectionViewDataSource(configuration: configuration)
+    epoxyDataSource = CollectionViewDataSource()
     self.configuration = configuration
     super.init(frame: .zero, collectionViewLayout: layout)
     setUp()

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -546,16 +546,15 @@ open class CollectionView: UICollectionView {
         performUpdates()
       }
     case .reloadData:
-      if let result = epoxyDataSource.applyData(data) {
-        updateState = .updating(from: result.oldData)
-      }
+      let result = epoxyDataSource.applyData(data)
+      updateState = .updating(from: result.oldData)
       reloadData()
       completeUpdates()
     }
   }
 
   private func performUpdates(data: CollectionViewData, animated: Bool) {
-    guard let result = epoxyDataSource.applyData(data) else { return }
+    let result = epoxyDataSource.applyData(data)
     updateState = .updating(from: result.oldData)
 
     for (fromIndexPath, toIndexPath) in result.changeset.itemChangeset.updates {

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -540,7 +540,10 @@ open class CollectionView: UICollectionView {
       })
     }
 
-    switch strategy {
+    // The first update should always be a `.reloadData`.
+    let overrideStrategy = (epoxyDataSource.data == nil) ? .reloadData : strategy
+
+    switch overrideStrategy {
     case .animatedBatchUpdates:
       performUpdates()
     case .nonanimatedBatchUpdates:

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -9,12 +9,6 @@ import UIKit
 /// The internal `UICollectionViewDataSource` of `CollectionView`.
 final class CollectionViewDataSource: NSObject {
 
-  // MARK: Lifecycle
-
-  init(configuration: CollectionViewConfiguration) {
-    self.configuration = configuration
-  }
-
   // MARK: Internal
 
   /// The result of applying new data to this data source.
@@ -86,7 +80,6 @@ final class CollectionViewDataSource: NSObject {
 
   // MARK: Private
 
-  private let configuration: CollectionViewConfiguration
   private let reuseIDStore = ReuseIDStore()
 
   /// The set of cell ViewDifferentiators that have been registered on the collection view.

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -51,16 +51,10 @@ final class CollectionViewDataSource: NSObject {
 
   /// Applies the given new data to this data source, returning old data and the minimal changes
   /// necessary to get to the provided new data.
-  func applyData(_ newData: CollectionViewData) -> ApplyDataResult? {
-    let oldData = data
+  func applyData(_ newData: CollectionViewData) -> ApplyDataResult {
+    let oldData = data ?? .make(sections: [])
     data = newData
-    if configuration.usesBatchUpdatesForAllReloads {
-      let oldData = oldData ?? .make(sections: [])
-      return .init(changeset: newData.makeChangeset(from: oldData), oldData: oldData)
-    } else {
-      guard let oldData = oldData else { return nil }
-      return .init(changeset: newData.makeChangeset(from: oldData), oldData: oldData)
-    }
+    return .init(changeset: newData.makeChangeset(from: oldData), oldData: oldData)
   }
 
   /// Refreshes the internalData but does not trigger a UI update.


### PR DESCRIPTION
## Change summary
Allow specifying that `CollectionView`s should update using non-animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than `reloadData()`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
