### PR TITLE
Improve CollectionView logic for reload data override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
 
+### Fixed
+- Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
+  in specific scenarios.
+
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 
 ### Added

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -540,10 +540,14 @@ open class CollectionView: UICollectionView {
       })
     }
 
-    // The first update should always be a `.reloadData`.
-    let overrideStrategy = (epoxyDataSource.data == nil) ? .reloadData : strategy
+    // There's two cases in which we should always have a strategy of `.reloadData`:
+    // - The first update, since we're going from empty content to non-empty content, and we don't
+    //   want to animate that update.
+    // - Before the first layout of this collection view when `bounds.size` is still zero, since
+    //   there's no benefit to doing batch updates in that scenario.
+    let override = (epoxyDataSource.data == nil || bounds.size == .zero) ? .reloadData : strategy
 
-    switch overrideStrategy {
+    switch override {
     case .animatedBatchUpdates:
       performUpdates()
     case .nonanimatedBatchUpdates:


### PR DESCRIPTION
## Change summary
When `bounds.size` is `.zero`, there's no benefit to doing batch updates.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
