### PR TITLE
Add reflowsForAccessibilityTypeSizes to HGroup.Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `UpdateStrategy` to `CollectionView` to allow specifying that it should update using non-
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
-- Added `reflowsForAccessibilityTypeSizes` property to `HGroup.Style`.
+- Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to `HGroup.Style`.
 
 ### Fixed
 - Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `UpdateStrategy` to `CollectionView` to allow specifying that it should update using non-
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
+- Added `reflowsForAccessibilityTypeSizes` property to `HGroup.Style`.
 
 ### Fixed
 - Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`

--- a/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
+++ b/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
@@ -22,6 +22,7 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     alignment = style.alignment
     accessibilityAlignment = style.accessibilityAlignment
     spacing = style.spacing
+    reflowsForAccessibilityTypeSizes = style.reflowsForAccessibilityTypeSizes
     self.items = erasedItems
     constrainableContainers = erasedItems.map { item in
       let constrainable = item.makeConstrainable()
@@ -120,14 +121,18 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     ///                              These will also be used if `forceVerticalAccessibilityLayout` is set to `true`.
     ///                              Individual item alignments will take precedence over this value
     ///   - spacing: the spacing between items of the group
+    ///   - reflowsForAccessibilityTypeSizes: whether or not this group should reflow when DynamicType
+    ///                                         is enabled and is an accessiblity size category
     public init(
       alignment: HGroup.ItemAlignment = .fill,
       accessibilityAlignment: VGroup.ItemAlignment = .leading,
-      spacing: CGFloat = 0)
+      spacing: CGFloat = 0,
+      reflowsForAccessibilityTypeSizes: Bool = true)
     {
       self.alignment = alignment
       self.accessibilityAlignment = accessibilityAlignment
       self.spacing = spacing
+      self.reflowsForAccessibilityTypeSizes = reflowsForAccessibilityTypeSizes
     }
 
     // MARK: Internal
@@ -135,6 +140,7 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     let alignment: HGroup.ItemAlignment
     let accessibilityAlignment: VGroup.ItemAlignment
     let spacing: CGFloat
+    let reflowsForAccessibilityTypeSizes: Bool
   }
 
   /// Alignment set at the group level to apply to all constrainables.

--- a/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
+++ b/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
@@ -23,6 +23,7 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     accessibilityAlignment = style.accessibilityAlignment
     spacing = style.spacing
     reflowsForAccessibilityTypeSizes = style.reflowsForAccessibilityTypeSizes
+    forceVerticalAccessibilityLayout = style.forceVerticalAccessibilityLayout
     self.items = erasedItems
     constrainableContainers = erasedItems.map { item in
       let constrainable = item.makeConstrainable()
@@ -122,17 +123,21 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     ///                              Individual item alignments will take precedence over this value
     ///   - spacing: the spacing between items of the group
     ///   - reflowsForAccessibilityTypeSizes: whether or not this group should reflow when DynamicType
-    ///                                         is enabled and is an accessiblity size category
+    ///                                         is enabled and is an accessiblity size category.
+    ///                                         The default value is `true`
+    ///   - forceVerticalAccessibilityLayout: force the group to use the the vertical accessibility layout
     public init(
       alignment: HGroup.ItemAlignment = .fill,
       accessibilityAlignment: VGroup.ItemAlignment = .leading,
       spacing: CGFloat = 0,
-      reflowsForAccessibilityTypeSizes: Bool = true)
+      reflowsForAccessibilityTypeSizes: Bool = true,
+      forceVerticalAccessibilityLayout: Bool = false)
     {
       self.alignment = alignment
       self.accessibilityAlignment = accessibilityAlignment
       self.spacing = spacing
       self.reflowsForAccessibilityTypeSizes = reflowsForAccessibilityTypeSizes
+      self.forceVerticalAccessibilityLayout = forceVerticalAccessibilityLayout
     }
 
     // MARK: Internal
@@ -141,6 +146,7 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     let accessibilityAlignment: VGroup.ItemAlignment
     let spacing: CGFloat
     let reflowsForAccessibilityTypeSizes: Bool
+    let forceVerticalAccessibilityLayout: Bool
   }
 
   /// Alignment set at the group level to apply to all constrainables.
@@ -163,14 +169,14 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
   /// When this property is true, the HGroup will automatically relayout when
   /// accessibility type sizes are enabled to make the layout more accessible
   /// the default value of this property is `true`
-  public var reflowsForAccessibilityTypeSizes = true {
+  public var reflowsForAccessibilityTypeSizes: Bool {
     didSet { installConstraintsIfNeeded() }
   }
 
   /// When this property is true, HGroup will only use the vertical accessibility
   /// layout. This is useful if you need to toggle a horizontal and vertical layout
   /// manually instead of relying on the built-in support from `reflowsForAccessibilityTypeSizes`
-  public var forceVerticalAccessibilityLayout = false {
+  public var forceVerticalAccessibilityLayout: Bool {
     didSet { installConstraintsIfNeeded() }
   }
 


### PR DESCRIPTION
## Change summary
This adds `reflowsForAccessibilityTypeSizes` to `HGroup.Style` to make it easier to set, and to make it possible to set when using `HGroupView` directly.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes

## Please review
@erichoracek 
