### PR TITLE
fix some issues with alignment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
 - Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to `HGroup.Style`.
-- Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
 
 ### Fixed
 - Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
   in specific scenarios.
+- Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
 
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
 - Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to `HGroup.Style`.
+- Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
 
 ### Fixed
 - Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
   in specific scenarios.
 - Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
+- Fixed an issue where `accessibilityAlignment` and `horizontalAlignment` would overwrite one another
 
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 

--- a/Sources/EpoxyLayoutGroups/Constrainable/ConstrainableContainer.swift
+++ b/Sources/EpoxyLayoutGroups/Constrainable/ConstrainableContainer.swift
@@ -14,11 +14,17 @@ public struct ConstrainableContainer: Constrainable, AnchoringContainer, EpoxyMo
 
   public init(_ constrainable: Constrainable) {
     self.constrainable = constrainable
-    if let container = constrainable as? ConstrainableContainer {
-      accessibilityAlignment = container.accessibilityAlignment
-      horizontalAlignment = container.horizontalAlignment
-      padding = container.padding
-      verticalAlignment = container.verticalAlignment
+    if let accessibilityAlignmentProviding = constrainable as? AccessibilityAlignmentProviding {
+      accessibilityAlignment = accessibilityAlignmentProviding.accessibilityAlignment
+    }
+    if let horizontalAlignmentProviding = constrainable as? HorizontalAlignmentProviding {
+      horizontalAlignment = horizontalAlignmentProviding.horizontalAlignment
+    }
+    if let paddingProviding = constrainable as? PaddingProviding {
+      padding = paddingProviding.padding
+    }
+    if let verticalAlignmentProviding = constrainable as? VerticalAlignmentProviding {
+      verticalAlignment = verticalAlignmentProviding.verticalAlignment
     }
   }
 
@@ -111,7 +117,7 @@ extension Constrainable {
   }
 
   /// Sets the accessibility alignment of this component in the group
-  public func accessibilityAlignment(_ alignment: VGroup.ItemAlignment) -> Constrainable {
+  public func accessibilityAlignment(_ alignment: VGroup.ItemAlignment?) -> Constrainable {
     var container = _containerOrSelf
     container.accessibilityAlignment = alignment
     return container

--- a/Sources/EpoxyLayoutGroups/Constraints/VGroupConstraints.swift
+++ b/Sources/EpoxyLayoutGroups/Constraints/VGroupConstraints.swift
@@ -151,7 +151,7 @@ final class VGroupConstraints: GroupConstraints {
   {
     var alignment = constrainable.horizontalAlignment ?? groupAlignment
     if useAccessibilityAlignment {
-      alignment = constrainable.accessibilityAlignment
+      alignment = constrainable.accessibilityAlignment ?? alignment
     }
     switch alignment {
     case .fill:
@@ -201,7 +201,7 @@ final class VGroupConstraints: GroupConstraints {
   {
     var alignment = constrainable.horizontalAlignment ?? groupAlignment
     if useAccessibilityAlignment {
-      alignment = constrainable.accessibilityAlignment
+      alignment = constrainable.accessibilityAlignment ?? alignment
     }
     switch alignment {
     case .fill:
@@ -265,7 +265,7 @@ final class VGroupConstraints: GroupConstraints {
 
     var alignment = constrainable.horizontalAlignment ?? groupAlignment
     if useAccessibilityAlignment {
-      alignment = constrainable.accessibilityAlignment
+      alignment = constrainable.accessibilityAlignment ?? alignment
     }
     switch alignment {
     case .fill:
@@ -317,7 +317,7 @@ final class VGroupConstraints: GroupConstraints {
   {
     var alignment = constrainable.horizontalAlignment ?? groupAlignment
     if useAccessibilityAlignment {
-      alignment = constrainable.accessibilityAlignment
+      alignment = constrainable.accessibilityAlignment ?? alignment
     }
     switch alignment {
     case .fill, .leading, .trailing, .center, .centered:

--- a/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
+++ b/Sources/EpoxyLayoutGroups/Groups/HGroup.swift
@@ -120,7 +120,8 @@ public final class HGroup: UILayoutGuide, Constrainable, InternalGroup {
     ///                              these will only be used when `reflowsForAccessibiltyTypeSizes` is `true`
     ///                              and when the `preferredContentSizeCategory.isAccessibilityCategory` is `true`.
     ///                              These will also be used if `forceVerticalAccessibilityLayout` is set to `true`.
-    ///                              Individual item alignments will take precedence over this value
+    ///                              Individual item alignments will take precedence over this value.
+    ///                              The default value of this property is `.leading`
     ///   - spacing: the spacing between items of the group
     ///   - reflowsForAccessibilityTypeSizes: whether or not this group should reflow when DynamicType
     ///                                         is enabled and is an accessiblity size category.

--- a/Sources/EpoxyLayoutGroups/Models/GroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/GroupItem.swift
@@ -301,7 +301,7 @@ extension GroupItem {
 /// removed and a new item view will be created and inserted in its place.
 private struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
-  var accessibilityAlignment: VGroup.ItemAlignment
+  var accessibilityAlignment: VGroup.ItemAlignment?
   var horizontalAlignment: VGroup.ItemAlignment?
   var padding: NSDirectionalEdgeInsets
   var verticalAlignment: HGroup.ItemAlignment?

--- a/Sources/EpoxyLayoutGroups/Models/HGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/HGroupItem.swift
@@ -144,7 +144,7 @@ private struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
   var style: HGroup.Style
   var reflowsForAccessibilityTypeSizes: Bool
-  var accessibilityAlignment: VGroup.ItemAlignment
+  var accessibilityAlignment: VGroup.ItemAlignment?
   var horizontalAlignment: VGroup.ItemAlignment?
   var padding: NSDirectionalEdgeInsets
   var verticalAlignment: HGroup.ItemAlignment?

--- a/Sources/EpoxyLayoutGroups/Models/StaticGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/StaticGroupItem.swift
@@ -22,6 +22,9 @@ import UIKit
 /// }
 /// ```
 public struct StaticGroupItem {
+
+  // MARK: Lifecycle
+
   public init(_ constrainable: Constrainable) {
     self.constrainable = constrainable
     if let accessibilityAlignmentProviding = constrainable as? AccessibilityAlignmentProviding {

--- a/Sources/EpoxyLayoutGroups/Models/StaticGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/StaticGroupItem.swift
@@ -24,11 +24,17 @@ import UIKit
 public struct StaticGroupItem {
   public init(_ constrainable: Constrainable) {
     self.constrainable = constrainable
-    if let container = constrainable as? ConstrainableContainer {
-      accessibilityAlignment = container.accessibilityAlignment
-      horizontalAlignment = container.horizontalAlignment
-      padding = container.padding
-      verticalAlignment = container.verticalAlignment
+    if let accessibilityAlignmentProviding = constrainable as? AccessibilityAlignmentProviding {
+      accessibilityAlignment = accessibilityAlignmentProviding.accessibilityAlignment
+    }
+    if let horizontalAlignmentProviding = constrainable as? HorizontalAlignmentProviding {
+      horizontalAlignment = horizontalAlignmentProviding.horizontalAlignment
+    }
+    if let paddingProviding = constrainable as? PaddingProviding {
+      padding = paddingProviding.padding
+    }
+    if let verticalAlignmentProviding = constrainable as? VerticalAlignmentProviding {
+      verticalAlignment = verticalAlignmentProviding.verticalAlignment
     }
   }
 
@@ -118,7 +124,7 @@ extension StaticGroupItem: VerticalAlignmentProviding { }
 /// removed and a new item view will be created and inserted in its place.
 private struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
-  var accessibilityAlignment: VGroup.ItemAlignment
+  var accessibilityAlignment: VGroup.ItemAlignment?
   var horizontalAlignment: VGroup.ItemAlignment?
   var padding: NSDirectionalEdgeInsets
   var verticalAlignment: HGroup.ItemAlignment?

--- a/Sources/EpoxyLayoutGroups/Models/VGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/VGroupItem.swift
@@ -138,7 +138,7 @@ extension VGroupItem: InternalGroupItemModeling {
 private struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
   var style: VGroup.Style
-  var accessibilityAlignment: VGroup.ItemAlignment
+  var accessibilityAlignment: VGroup.ItemAlignment?
   var horizontalAlignment: VGroup.ItemAlignment?
   var padding: NSDirectionalEdgeInsets
   var verticalAlignment: HGroup.ItemAlignment?

--- a/Sources/EpoxyLayoutGroups/Providers/AccessibilityAlignmentProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/AccessibilityAlignmentProviding.swift
@@ -12,8 +12,8 @@ public protocol AccessibilityAlignmentProviding {
   /// when the `preferredContentSizeCategory.isAccessibilityCategory` is `true`.
   /// That accessibility layout essentially converts the `HGroup` into a `VGroup` and
   /// uses the provided `accessibilityAlignment` value for each item to determine the layout.
-  /// The default value of this property is `.leading`.
-  var accessibilityAlignment: VGroup.ItemAlignment { get }
+  /// The default value of this property is `nil`.
+  var accessibilityAlignment: VGroup.ItemAlignment? { get }
 }
 
 // MARK: - EpoxyModeled + AccessibilityAlignmentProviding
@@ -23,20 +23,20 @@ extension EpoxyModeled where Self: AccessibilityAlignmentProviding {
   // MARK: Public
 
   /// The accessibilityAlignment value for this model
-  public var accessibilityAlignment: VGroup.ItemAlignment {
+  public var accessibilityAlignment: VGroup.ItemAlignment? {
     get { self[accessibilityAlignmentProperty] }
     set { self[accessibilityAlignmentProperty] = newValue }
   }
 
   /// Returns a copy of this model replacing the `accessibiltyAlignment` value
   /// with the one provided.
-  public func accessibilityAlignment(_ value: VGroup.ItemAlignment) -> Self {
+  public func accessibilityAlignment(_ value: VGroup.ItemAlignment?) -> Self {
     copy(updating: accessibilityAlignmentProperty, to: value)
   }
 
   // MARK: Private
 
-  private var accessibilityAlignmentProperty: EpoxyModelProperty<VGroup.ItemAlignment> {
-    .init(keyPath: \Self.accessibilityAlignment, defaultValue: .leading, updateStrategy: .replace)
+  private var accessibilityAlignmentProperty: EpoxyModelProperty<VGroup.ItemAlignment?> {
+    .init(keyPath: \Self.accessibilityAlignment, defaultValue: nil, updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/AccessibilityAlignmentProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/AccessibilityAlignmentProviding.swift
@@ -37,6 +37,6 @@ extension EpoxyModeled where Self: AccessibilityAlignmentProviding {
   // MARK: Private
 
   private var accessibilityAlignmentProperty: EpoxyModelProperty<VGroup.ItemAlignment?> {
-    .init(keyPath: \Self.accessibilityAlignment, defaultValue: nil, updateStrategy: .replace)
+    .init(keyPath: \AccessibilityAlignmentProviding.accessibilityAlignment, defaultValue: nil, updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/GroupItemsProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/GroupItemsProviding.swift
@@ -32,6 +32,6 @@ extension EpoxyModeled where Self: GroupItemsProviding {
   // MARK: Private
 
   private var groupItemsProperty: EpoxyModelProperty<[GroupItemModeling]> {
-    .init(keyPath: \Self.groupItems, defaultValue: [], updateStrategy: .replace)
+    .init(keyPath: \GroupItemsProviding.groupItems, defaultValue: [], updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/HorizontalAlignmentProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/HorizontalAlignmentProviding.swift
@@ -35,6 +35,6 @@ extension EpoxyModeled where Self: HorizontalAlignmentProviding {
   // MARK: Private
 
   private var horizontalAlignmentProperty: EpoxyModelProperty<VGroup.ItemAlignment?> {
-    .init(keyPath: \Self.horizontalAlignment, defaultValue: nil, updateStrategy: .replace)
+    .init(keyPath: \HorizontalAlignmentProviding.horizontalAlignment, defaultValue: nil, updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/MakeConstrainableProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/MakeConstrainableProviding.swift
@@ -37,7 +37,7 @@ extension EpoxyModeled where Self: MakeConstrainableProviding {
 
   private var makeConstrainableProperty: EpoxyModelProperty<MakeConstrainable> {
     .init(
-      keyPath: \Self.makeConstrainable,
+      keyPath: \MakeConstrainableProviding.makeConstrainable,
       defaultValue: UIView.init,
       updateStrategy: .replace)
   }

--- a/Sources/EpoxyLayoutGroups/Providers/PaddingProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/PaddingProviding.swift
@@ -39,6 +39,6 @@ extension EpoxyModeled where Self: PaddingProviding {
   // MARK: Private
 
   private var paddingProperty: EpoxyModelProperty<NSDirectionalEdgeInsets> {
-    .init(keyPath: \Self.padding, defaultValue: .zero, updateStrategy: .replace)
+    .init(keyPath: \PaddingProviding.padding, defaultValue: .zero, updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/ReflowsForAccessibilityTypeSizeProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/ReflowsForAccessibilityTypeSizeProviding.swift
@@ -35,6 +35,6 @@ extension EpoxyModeled where Self: ReflowsForAccessibilityTypeSizeProviding {
   // MARK: Private
 
   private var reflowsForAccessibilityTypeSizeProperty: EpoxyModelProperty<Bool> {
-    .init(keyPath: \Self.reflowsForAccessibilityTypeSizes, defaultValue: true, updateStrategy: .replace)
+    .init(keyPath: \ReflowsForAccessibilityTypeSizeProviding.reflowsForAccessibilityTypeSizes, defaultValue: true, updateStrategy: .replace)
   }
 }

--- a/Sources/EpoxyLayoutGroups/Providers/VerticalAlignmentProviding.swift
+++ b/Sources/EpoxyLayoutGroups/Providers/VerticalAlignmentProviding.swift
@@ -35,6 +35,6 @@ extension EpoxyModeled where Self: VerticalAlignmentProviding {
   // MARK: Private
 
   private var verticalAlignmentProperty: EpoxyModelProperty<HGroup.ItemAlignment?> {
-    .init(keyPath: \Self.verticalAlignment, defaultValue: nil, updateStrategy: .replace)
+    .init(keyPath: \VerticalAlignmentProviding.verticalAlignment, defaultValue: nil, updateStrategy: .replace)
   }
 }

--- a/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
+++ b/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
@@ -14,7 +14,7 @@ final class ConstraniableContainerSpec: QuickSpec {
     beforeEach {
       constrainable = TestView()
         .accessibilityAlignment(.trailing)
-        .horizontalAlignment(.leading)
+        .horizontalAlignment(.center)
         .verticalAlignment(.top)
         .padding(5)
     }
@@ -23,7 +23,7 @@ final class ConstraniableContainerSpec: QuickSpec {
       it("inherits the values of the provided Constrainable") {
         let wrapper = ConstrainableContainer(constrainable)
         expect(wrapper.accessibilityAlignment).to(equal(.trailing))
-        expect(wrapper.horizontalAlignment).to(equal(.leading))
+        expect(wrapper.horizontalAlignment).to(equal(.center))
         expect(wrapper.verticalAlignment).to(equal(.top))
         expect(wrapper.padding).to(equal(NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)))
       }

--- a/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
+++ b/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
@@ -1,0 +1,34 @@
+// Created by Tyler Hedrick on 5/26/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Nimble
+import Quick
+@testable import EpoxyLayoutGroups
+import UIKit
+
+final class ConstraniableContainerSpec: QuickSpec {
+
+  override func spec() {
+    var constrainable: Constrainable!
+
+    beforeEach {
+      constrainable = TestView()
+        .accessibilityAlignment(.trailing)
+        .horizontalAlignment(.leading)
+        .verticalAlignment(.top)
+        .padding(5)
+    }
+
+    describe("when initializing a ConstrainableContainer with another ConstrainableContainer") {
+      it("inherits the values of the provided ConstrainableContainer") {
+        let wrapper = ConstrainableContainer(constrainable)
+        expect(wrapper.accessibilityAlignment).to(equal(.trailing))
+        expect(wrapper.horizontalAlignment).to(equal(.leading))
+        expect(wrapper.verticalAlignment).to(equal(.top))
+        expect(wrapper.padding).to(equal(NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)))
+      }
+    }
+
+  }
+
+}

--- a/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
+++ b/Tests/EpoxyTests/LayoutGroupsTests/ConstrainableContainerSpec.swift
@@ -19,8 +19,8 @@ final class ConstraniableContainerSpec: QuickSpec {
         .padding(5)
     }
 
-    describe("when initializing a ConstrainableContainer with another ConstrainableContainer") {
-      it("inherits the values of the provided ConstrainableContainer") {
+    describe("when initializing a ConstrainableContainer with another Constrainable") {
+      it("inherits the values of the provided Constrainable") {
         let wrapper = ConstrainableContainer(constrainable)
         expect(wrapper.accessibilityAlignment).to(equal(.trailing))
         expect(wrapper.horizontalAlignment).to(equal(.leading))


### PR DESCRIPTION
## Change summary
This fixes an issue where VGroupConstraints in an accessibility layout would not respect the provided accessibility group alignment value because `AccessibilityAlignmentProviding` was non-optional. This change makes that property optional to match the other alignment values, and fixes the issue by using the group alignment when an individual `accessibilityAlignment` value is not provided.

As part of this I updated ConstrainableContainer and StaticGroupItem to use the provider protocols instead of ConstrainableContainer to inherit values

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [x] built a test view to ensure this was working properly

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes

## Please review
@erichoracek 
