### PR TITLE
Use collection view batch updates for all reloads by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `CollectionViewConfiguration.usesBatchUpdatesForAllReloads` now defaults to `true`.
-- `CollectionViewConfiguration` was changed to a `struct` from an immutable `class` to make it
-  easier to modify an existing configuration.
+- Changed `CollectionViewConfiguration` from an immutable `class` to a `struct` to make it easier to
+  modify an existing configuration.
 
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.3.0...HEAD)
+## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.4.0...HEAD)
 
 ### Added
 - Added an `UpdateStrategy` to `CollectionView` to allow specifying that it should update using non-
@@ -13,10 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to `HGroup.Style`.
 
 ### Fixed
-- Improve `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
+- Improved `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
   in specific scenarios.
 - Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
 - Fixed an issue where `accessibilityAlignment` and `horizontalAlignment` would overwrite one another
+
+### Changed
+- `CollectionViewConfiguration.usesBatchUpdatesForAllReloads` now defaults to `true`.
+- `CollectionViewConfiguration` was changed to a `struct` from an immutable `class` to make it
+  easier to modify an existing configuration.
 
 ## [0.4.0](https://github.com/airbnb/epoxy-ios/compare/0.3.0...0.4.0) - 2021-05-17
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -28,13 +28,23 @@ public struct CollectionViewConfiguration {
   /// Set this to a new instance to override the default configuration.
   public static var shared = CollectionViewConfiguration()
 
-  /// UIKit engineers have suggested that we should never call `reloadData` ourselves, and instead,
-  /// use batch updates for all data changes.
+  /// When `true`, `CollectionView` performs non-animated content updates by wrapping a call to
+  /// `performBatchUpdates(…)` with the new content within a `UIView.performWithoutAnimation(…)`
+  /// closure.
+  ///
+  /// UIKit engineers have suggested that we should never call `reloadData(…)` ourselves, and
+  /// instead, use batch updates for all data changes. `performBatchUpdates(…)` is more performant
+  /// and reliable than `reloadData(…)`, as it does not recreate and reconfigure all visible cells.
+  ///
+  /// When `false`, `CollectionView` performs non-animated updates by calling `reloadData(…)`, which
+  /// recreates and reconfigures all visible cells.
   ///
   /// Defaults to `true`.
+  ///
+  /// - SeeAlso: `CollectionView.UpdateStrategy`
   public var usesBatchUpdatesForAllReloads: Bool
 
-  /// In the past, UICollectionView has crashed when prefetching was enabled. There were also some
+  /// In the past, `UICollectionView` has crashed when prefetching was enabled. There were also some
   /// other issues:
   ///
   /// - Rendering issues on iOS 10, 11 and maybe newer versions when using self-sizing supplementary
@@ -48,11 +58,13 @@ public struct CollectionViewConfiguration {
   /// Defaults to `true`.
   public var usesCellPrefetching: Bool
 
-  /// Collection view does not accurately scroll to items if they're self-sized, due to it using
-  /// estimated heights to calculate the final offset. Setting this to true will cause
+  /// `UICollectionView` does not accurately scroll to items if they're self-sized, due to it using
+  /// estimated heights to calculate the final offset. Setting this to `true` will cause
   /// `CollectionView` to use a custom scroll-to-item implementation which is more accurate.
   ///
   /// Defaults to `true`.
+  ///
+  /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
 
 }

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -6,12 +6,12 @@
 ///
 /// Can additionally be provided when initializing a `CollectionView` to customize the behavior of
 /// that specific instance.
-public final class CollectionViewConfiguration {
+public struct CollectionViewConfiguration {
 
   // MARK: Lifecycle
 
   public init(
-    usesBatchUpdatesForAllReloads: Bool = false,
+    usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
     usesAccurateScrollToItem: Bool = true)
   {
@@ -31,8 +31,8 @@ public final class CollectionViewConfiguration {
   /// UIKit engineers have suggested that we should never call `reloadData` ourselves, and instead,
   /// use batch updates for all data changes.
   ///
-  /// Defaults to `false`.
-  public let usesBatchUpdatesForAllReloads: Bool
+  /// Defaults to `true`.
+  public var usesBatchUpdatesForAllReloads: Bool
 
   /// In the past, UICollectionView has crashed when prefetching was enabled. There were also some
   /// other issues:
@@ -46,13 +46,13 @@ public final class CollectionViewConfiguration {
   /// If this is set to `true`, then cell-prefetching will be turned on by default.
   ///
   /// Defaults to `true`.
-  public let usesCellPrefetching: Bool
+  public var usesCellPrefetching: Bool
 
   /// Collection view does not accurately scroll to items if they're self-sized, due to it using
   /// estimated heights to calculate the final offset. Setting this to true will cause
   /// `CollectionView` to use a custom scroll-to-item implementation which is more accurate.
   ///
   /// Defaults to `true`.
-  public let usesAccurateScrollToItem: Bool
+  public var usesAccurateScrollToItem: Bool
 
 }


### PR DESCRIPTION
## Change summary
While we're here, we additionally update `CollectionViewConfiguration` to be a struct to make it easier to mutate an existing configuration.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
