### PR TITLE
Break temporary retain cycle in system presentation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in specific scenarios.
 - Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
 - Fixed an issue where `accessibilityAlignment` and `horizontalAlignment` would overwrite one another
+- Break a temporary retain cycle in `.system` presentation style
 
 ### Changed
 - `CollectionViewConfiguration.usesBatchUpdatesForAllReloads` now defaults to `true`.

--- a/Sources/EpoxyPresentations/PresentationModel.swift
+++ b/Sources/EpoxyPresentations/PresentationModel.swift
@@ -290,10 +290,10 @@ extension PresentationModel.Presentation {
             forName: .init("\(UIPresentationController.self)DismissalTransitionDidEndNotification"),
             object: presented,
             queue: .main,
-            using: { _ in
+            using: { [didDismiss = context.didDismiss] _ in
               guard token != nil else { return }
               token = nil
-              context.didDismiss()
+              didDismiss()
             })
 
         context.presenting.present(


### PR DESCRIPTION
## Change summary
By retaining the entire `context` in the captured observer closure, we're implicitly capturing the `context.presenting` `UIViewController` for the duration of the transition until the `DismissalTransitionDidEndNotification` notification is fired.

If the `DismissalTransitionDidEndNotification` is never triggered, e.g. in the case of early deallocation following presentation, this could lead to the presenting view controller being retained indefinitely.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
