### PR TITLE
Fixed incorrect OOB assert logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.5.0...HEAD)
 
+### Fixed
+- Fixed incorrect assertion logging when accessing an item with an invalid index path.
+
 ## [0.5.0](https://github.com/airbnb/epoxy-ios/compare/0.4.0...0.5.0) - 2021-06-23
 
 ### Added

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewData.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewData.swift
@@ -73,7 +73,7 @@ struct CollectionViewData {
     guard indexPath.row < section.items.count else {
       EpoxyLogger.shared.assertionFailure(
         """
-        Item index \(indexPath.section) is out of bounds \(section.items.count). Make sure your \
+        Item index \(indexPath.item) is out of bounds \(section.items.count). Make sure your \
         section models and item models all have unique dataIDs.
         """)
       return nil


### PR DESCRIPTION
## Change summary
- noticed this assert was logging the `indexPath.section` instead of `indexPath.item`

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
