### PR TITLE
[EpoxyBars] Add `insetMargins` property to `TopBarContainer` and `BottomBarContainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.5.0...HEAD)
 
+### Added
+
+- Added an `insetMargins` property to `TopBarContainer` and `BottomBarContainer` that configures whether or not the container sets layout margins derived from the `safeAreaInsets` of its `viewController`.
+
 ### Fixed
 - Fixed incorrect assertion logging when accessing an item with an invalid index path.
 - Mitigated a `EXC_BAD_ACCESS` crash that caused by a bad `nonnull` bridge in `CollectionViewCell`.

--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -215,8 +215,7 @@ extension InternalBarContainer {
 
   /// Sets the `layoutMargin` corresponding to the container's `position`
   func setLayoutMargin(_ margin: CGFloat) {
-    guard insetMargins else { return }
-    layoutMargins[keyPath: position.inset] = margin
+    layoutMargins[keyPath: position.inset] = insetMargins ? margin : 0
   }
 
   // MARK: Private

--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -63,6 +63,11 @@ protocol InternalBarContainer: BarContainer {
 
   /// Whether or not the additional safe area insets need to be reset to 0
   var needsSafeAreaInsetReset: Bool { get set }
+
+  /// Whether or not this bar container should apply `layoutMargins`
+  /// derived from the `viewController`'s `safeAreaInsets`.
+  ///  - `true` by default.
+  var insetMargins: Bool { get set }
 }
 
 // MARK: - BarContainerPosition
@@ -206,6 +211,12 @@ extension InternalBarContainer {
     EpoxyLogger.shared.assert(
       !(viewController.view is UIScrollView),
       "The view controller's view must not be a scroll view. Nest any scroll views in a container.")
+  }
+
+  /// Sets the `layoutMargin` corresponding to the container's `position`
+  func setLayoutMargin(_ margin: CGFloat) {
+    guard insetMargins else { return }
+    layoutMargins[keyPath: position.inset] = margin
   }
 
   // MARK: Private

--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -65,7 +65,7 @@ protocol InternalBarContainer: BarContainer {
   var needsSafeAreaInsetReset: Bool { get set }
 
   /// Whether or not this bar container should apply `layoutMargins`
-  /// derived from the `viewController`'s `safeAreaInsets`.
+  /// derived from the `viewController`'s `safeAreaInsets` to its bars.
   ///  - `true` by default.
   var insetMargins: Bool { get set }
 }

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -47,6 +47,13 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
     didSet { verifyViewController() }
   }
 
+  public var insetMargins: Bool = true {
+    didSet {
+      guard insetMargins != oldValue else { return }
+      setNeedsLayout()
+    }
+  }
+
   /// An additional bottom offset that can be applied to this bar stack's position.
   ///
   /// Typically used to offset the bar stack to avoid the keyboard.
@@ -156,7 +163,7 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
     // as the safe area no longer overlaps the bar.
     let margin = (bottomOffset > 0) ? 0 : viewController?.originalSafeAreaInsetBottom ?? 0
     updateScrollViewInset(allScrollViews, margin: margin)
-    layoutMargins.bottom = margin
+    setLayoutMargin(margin)
   }
 
 }

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -48,6 +48,13 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
     didSet { updateInsetBehavior(from: oldValue) }
   }
 
+  public var insetMargins: Bool = true {
+    didSet {
+      guard insetMargins != oldValue else { return }
+      setNeedsLayout()
+    }
+  }
+
   /// The behavior of the status bar when it's hidden.
   ///
   /// Can be called from within an animation block to animate changes to the hiding behavior.
@@ -187,7 +194,7 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
 
     let margin = layoutMarginsTop + extraLayoutMarginsTop
     updateScrollViewInset(allScrollViews, margin: margin)
-    layoutMargins.top = margin
+    setLayoutMargin(margin)
 
     // Make sure to keep any scroll views at top/bottom when adjusting content/safe area insets.
     scrollToEdge(scrollViewsAtEdge)

--- a/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
@@ -93,6 +93,15 @@ extension BaseBarInstallerSpec {
           setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
           expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(0))
         }
+
+        it("clears layout margins when changing from insetMargins=true to insetMargins=true") {
+          container.insetMargins = true
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(defaultSafeAreaInset))
+
+          container.insetMargins = false
+          expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(0))
+        }
       }
     }
   }

--- a/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
@@ -19,13 +19,17 @@ protocol BaseBarInstallerSpec {
 extension BaseBarInstallerSpec {
 
   func baseSpec() {
+    let defaultSafeAreaInset: CGFloat = 20
     var window: UIWindow!
     var viewController: UIViewController!
     var container: InternalBarContainer!
     var setBars: (([BarModeling]) -> Void)!
 
     beforeEach {
-      window = UIWindow(frame: .init(origin: CGPoint(x: 0, y: 100), size: CGSize(width: 300, height: 300)))
+      window = SafeAreaWindow(
+        frame: .init(origin: CGPoint(x: 0, y: 100), size: CGSize(width: 300, height: 300)),
+        safeAreaInsets: UIEdgeInsets(top: defaultSafeAreaInset, left: 0, bottom: defaultSafeAreaInset, right: 0))
+
       viewController = UIViewController()
       viewController.loadView()
       viewController.view.frame = window.bounds
@@ -47,22 +51,22 @@ extension BaseBarInstallerSpec {
       context("with a 100pt bar") {
         it("sets 100pt inset when using .barHeightSafeArea") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
         }
 
         it("updates to 200pt inset when updating bar height") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
 
-          setBars([StaticHeightBar.barModel(style: .init(height: 200))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 200 + defaultSafeAreaInset))])
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(200))
         }
 
         it("doesn't override custom inset when using .none") {
           container.insetBehavior = .none
-          setBars([StaticHeightBar.barModel(style: .init(height: 100))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(0))
 
           viewController.additionalSafeAreaInsets[keyPath: container.position.inset] = 50
@@ -71,11 +75,23 @@ extension BaseBarInstallerSpec {
 
         it("sets inset to 0 when changing from .barHeightSafeArea to .none") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
 
           container.insetBehavior = .none
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(0))
+        }
+
+        it("sets layout margins when insetMargins=true") {
+          container.insetMargins = true
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(defaultSafeAreaInset))
+        }
+
+        it("doesn't set layout margins when insetMargins=false") {
+          container.insetMargins = false
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(0))
         }
       }
     }

--- a/Tests/EpoxyTests/BarsTests/SafeAreaWindow.swift
+++ b/Tests/EpoxyTests/BarsTests/SafeAreaWindow.swift
@@ -1,0 +1,34 @@
+// Created by Cal Stephens on 8/23/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import UIKit
+
+// A `UIWindow` subclass that can provide safe area insets
+// to simulate default device safe area insets (e.g. from the status bar)
+final class SafeAreaWindow: UIWindow {
+
+  // MARK: Lifecycle
+
+  init(
+    frame: CGRect,
+    safeAreaInsets: UIEdgeInsets)
+  {
+    self.customSafeAreaInsets = safeAreaInsets
+    super.init(frame: frame)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  override var safeAreaInsets: UIEdgeInsets {
+    customSafeAreaInsets
+  }
+
+  // MARK: Private
+
+  private let customSafeAreaInsets: UIEdgeInsets
+
+}


### PR DESCRIPTION
## Change summary

This PR adds an `insetMargins` property to `TopBarContainer` and `BottomBarContainer` that configures whether or not the container sets layout margins derived from the `safeAreaInsets` of its `viewController`.

## How was it tested?
- [x] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
