### PR TITLE
[EpoxyLayoutGroups] fix diffIdentifier with mismatched styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed incorrect assertion logging when accessing an item with an invalid index path.
 - Mitigated a `EXC_BAD_ACCESS` crash that caused by a bad `nonnull` bridge in `CollectionViewCell`.
+- Fixed an issue where styles were not being used in the `diffIdentifier` calculation of `GroupItems`.
 
 ## [0.5.0](https://github.com/airbnb/epoxy-ios/compare/0.4.0...0.5.0) - 2021-06-23
 

--- a/Example/EpoxyExample/ViewControllers/LayoutGroups/ComplexDeclarativeViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/LayoutGroups/ComplexDeclarativeViewController.swift
@@ -73,9 +73,15 @@ final class ComplexDeclarativeViewController: UIViewController {
     ]
     let numberOfItems = Int.random(in: 1..<possibleItems.count)
     let allIndicies = Array(0...numberOfItems).shuffled()
+    let textStyles: [UIFont.TextStyle] = [
+      .title2,
+      .title3,
+      .body,
+    ]
 
     return allIndicies.map { index in
       let color = possibleItems[index]
+      let textStyle = textStyles.randomElement() ?? .title3
       return HGroupItem(
         dataID: color.0,
         style: .init(spacing: 8))
@@ -83,7 +89,7 @@ final class ComplexDeclarativeViewController: UIViewController {
         Label.groupItem(
           dataID: color.0 + "label",
           content: color.0,
-          style: .style(with: .title3))
+          style: .style(with: textStyle))
         SpacerItem(dataID: DataID.spacer)
         ColorView.groupItem(
           dataID: color.1,

--- a/Sources/EpoxyLayoutGroups/Extensions/StyledView+GroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Extensions/StyledView+GroupItem.swift
@@ -21,8 +21,9 @@ extension StyledView where Self: EpoxyableView {
   {
     GroupItem<Self>(
       dataID: dataID,
+      params: style,
       content: content,
-      make: { Self(style: style) },
+      make: { Self(style: $0) },
       setContent: { context, content in
         context.constrainable.setContent(content, animated: context.animated)
       })

--- a/Sources/EpoxyLayoutGroups/Models/GroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/GroupItem.swift
@@ -62,6 +62,7 @@ public struct GroupItem<ItemType: Constrainable>: EpoxyModeled {
   {
     self.make = { make(params) }
     self.dataID = dataID
+    self.styleID = params
     erasedContent = content
     self.setContent = { setContent($0, content) }
     isErasedContentEqual = { otherModel in
@@ -205,6 +206,10 @@ extension GroupItem: SetBehaviorsProviding { }
 
 extension GroupItem: SetContentProviding { }
 
+// MARK: StyleIDProviding
+
+extension GroupItem: StyleIDProviding { }
+
 // MARK: VerticalAlignmentProviding
 
 extension GroupItem: VerticalAlignmentProviding { }
@@ -277,6 +282,7 @@ extension GroupItem {
   public var diffIdentifier: AnyHashable {
     DiffIdentifier(
       dataID: dataID,
+      styleID: styleID,
       accessibilityAlignment: accessibilityAlignment,
       horizontalAlignment: horizontalAlignment,
       padding: padding,
@@ -301,6 +307,7 @@ extension GroupItem {
 /// removed and a new item view will be created and inserted in its place.
 private struct DiffIdentifier: Hashable {
   var dataID: AnyHashable
+  var styleID: AnyHashable?
   var accessibilityAlignment: VGroup.ItemAlignment?
   var horizontalAlignment: VGroup.ItemAlignment?
   var padding: NSDirectionalEdgeInsets
@@ -308,6 +315,7 @@ private struct DiffIdentifier: Hashable {
 
   func hash(into hasher: inout Hasher) {
     hasher.combine(dataID)
+    hasher.combine(styleID)
     hasher.combine(accessibilityAlignment)
     hasher.combine(horizontalAlignment)
     hasher.combine(verticalAlignment)

--- a/Tests/EpoxyTests/LayoutGroupsTests/GroupItemSpec.swift
+++ b/Tests/EpoxyTests/LayoutGroupsTests/GroupItemSpec.swift
@@ -9,10 +9,13 @@ import UIKit
 final class GroupItemSpec: QuickSpec {
 
   override func spec() {
-    var groupItem: GroupItem<TestLabel>!
+    var groupItem: GroupItem<TestStyledLabel>!
 
     beforeEach {
-      groupItem = TestLabel.groupItem(dataID: 1, content: .init(text: "text"))
+      groupItem = TestStyledLabel.groupItem(
+        dataID: 1,
+        content: "text",
+        style: .init(textStyle: .body))
     }
 
     describe("when modifiers are applied") {
@@ -56,11 +59,50 @@ final class GroupItemSpec: QuickSpec {
     }
 
     it("uses content to calculate equality") {
-      let other = TestLabel.groupItem(dataID: 1, content: .init(text: "Different"))
+      let other = TestStyledLabel.groupItem(
+        dataID: 1,
+        content: "Different",
+        style: .init(textStyle: .body))
       expect(groupItem.isDiffableItemEqual(to: other)).to(beFalse())
 
-      let otherEqual = TestLabel.groupItem(dataID: 1, content: .init(text: "text"))
+      let otherEqual = TestStyledLabel.groupItem(
+        dataID: 1,
+        content: "text",
+        style: .init(textStyle: .body))
       expect(groupItem.isDiffableItemEqual(to: otherEqual)).to(beTrue())
+    }
+
+    describe("different styles") {
+      beforeEach {
+        groupItem = TestStyledLabel.groupItem(
+          dataID: "1",
+          content: "Hello",
+          style: .init(textStyle: .body))
+      }
+
+      it("has the same diffIdentifier with different content and the same style") {
+        let otherItem = TestStyledLabel.groupItem(
+          dataID: "1",
+          content: "Hello, other label",
+          style: .init(textStyle: .body))
+        expect(groupItem.diffIdentifier).to(equal(otherItem.diffIdentifier))
+      }
+
+      it("has the same diffIdentifier with the same content and same style") {
+        let otherItem = TestStyledLabel.groupItem(
+          dataID: "1",
+          content: "Hello",
+          style: .init(textStyle: .body))
+        expect(groupItem.diffIdentifier).to(equal(otherItem.diffIdentifier))
+      }
+
+      it("has a different diffIdentifier with the same content and a different style") {
+        let otherItem = TestStyledLabel.groupItem(
+          dataID: "1",
+          content: "Hello",
+          style: .init(textStyle: .title2))
+        expect(groupItem.diffIdentifier).toNot(equal(otherItem.diffIdentifier))
+      }
     }
   }
 

--- a/Tests/EpoxyTests/LayoutGroupsTests/TestHelpers.swift
+++ b/Tests/EpoxyTests/LayoutGroupsTests/TestHelpers.swift
@@ -48,6 +48,29 @@ final class TestLabel: UILabel, EpoxyableView {
   }
 }
 
+final class TestStyledLabel: UILabel, EpoxyableView {
+
+  init(style: Style) {
+    super.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+    font = .preferredFont(forTextStyle: style.textStyle)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  struct Style: Hashable {
+    let textStyle: UIFont.TextStyle
+  }
+
+  typealias Content = String
+
+  func setContent(_ content: String, animated: Bool) {
+    text = content
+  }
+}
+
 extension XCTestCase {
 
   // MARK: Internal


### PR DESCRIPTION
## Change summary
This fixes #46 

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Wrote automated tests
- [x] Built and ran on the iOS simulator

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes