### PR TITLE
[EpoxyBars] Support global and per instance bar installer configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a `BarInstallerConfiguration` type to allow both global and per-instance configuration of
   bar installers.
-- Added an `applyBarModels` closure to `BarInstallerConfiguration` to allow consumers to configure
-  _when_ bars are applied to the underlying `BarContainer` by a bar installer, e.g. to defer bar
-  model updates that might conflict with an in-flight shared element transition.
+- Added an `applyBars` closure to `BarInstallerConfiguration` to allow consumers to configure _when_
+  bars are applied to the underlying `BarContainer` by a bar installer, e.g. to defer bar model
+  updates that might conflict with an in-flight shared element transition.
 
 ### Changed
 - Removed the default bar installer behavior where bar model updates were deferred while a view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.6.0...HEAD)
 
+### Added
+- Added a `BarInstallerConfiguration` type to allow both global and per-instance configuration of
+  bar installers.
+- Added an `applyBarModels` closure to `BarInstallerConfiguration` to allow consumers to configure
+  _when_ bars are applied to the underlying `BarContainer` by a bar installer, e.g. to defer bar
+  model updates that might conflict with an in-flight shared element transition.
+
+### Changed
+- Removed the default bar installer behavior where bar model updates were deferred while a view
+  controller transition is in progress.
+
 ## [0.6.0](https://github.com/airbnb/epoxy-ios/compare/0.5.0...0.6.0) - 2021-08-31
 
 ### Added

--- a/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/TextFieldViewController.swift
@@ -32,7 +32,7 @@ final class TextFieldViewController: CollectionViewController {
     avoidsKeyboard: true,
     bars: [buttonRowBar])
 
-  private var username: String = "@airbnb" {
+  private var username = "@airbnb" {
     didSet { setItems([textFieldRowItem], animated: true) }
   }
 

--- a/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
@@ -99,20 +99,18 @@ final class BarInstaller<Container: BarContainer> {
   private var storage = [BarCoordinatorPropertyKey: StoredCoordinatorProperty]()
 
   /// Updates the models to the given collection, installing the container if needed.
-  private func setBars(_ models: [BarModeling], animated: Bool, in view: UIView) {
-    bars = models
+  private func setBars(_ bars: [BarModeling], animated: Bool, in view: UIView) {
+    self.bars = bars
 
     guard let container = container else {
-      installContainer(in: view, with: models, animated: animated)
+      installContainer(in: view, with: bars, animated: animated)
       return
     }
 
-    if let apply = configuration.applyBarModels {
-      apply {
-        container.setBars(models, animated: animated)
-      }
+    if let applyBars = configuration.applyBars {
+      applyBars(container, bars, animated)
     } else {
-      container.setBars(models, animated: animated)
+      container.setBars(bars, animated: animated)
     }
   }
 

--- a/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstaller.swift
@@ -11,8 +11,9 @@ final class BarInstaller<Container: BarContainer> {
 
   // MARK: Lifecycle
 
-  init(viewController: UIViewController?) {
+  init(viewController: UIViewController?, configuration: BarInstallerConfiguration = .shared) {
     self.viewController = viewController
+    self.configuration = configuration
   }
 
   // MARK: Internal
@@ -24,7 +25,7 @@ final class BarInstaller<Container: BarContainer> {
 
   /// Updates the bars to the given models, ordered from top to bottom.
   ///
-  /// If any model correponds to the same view as was previously set, the view will be reused and
+  /// If any model corresponds to the same view as was previously set, the view will be reused and
   /// updated with the new content, optionally animated.
   ///
   /// If any model corresponds to a new bar, a new bar view will be created and inserted,
@@ -79,7 +80,9 @@ final class BarInstaller<Container: BarContainer> {
     var updateCoordinator: (_ coordinator: AnyObject, _ value: Any) -> Void
   }
 
-  /// The bar models that will be set on the container once its visible.
+  private let configuration: BarInstallerConfiguration
+
+  /// The bar models that will be set on the container once it's visible.
   private var bars: [BarModeling] = []
 
   /// Closures that are called whenever the bar coordinator property changes.
@@ -104,17 +107,10 @@ final class BarInstaller<Container: BarContainer> {
       return
     }
 
-    // When the view controller is actively participating in a transition, we should wait until the
-    // transition is over before we update the bars to ensure shared elements remain constant over
-    // the course of the transition.
-    if
-      let viewController = viewController,
-      let coordinator = viewController.transitionCoordinator,
-      viewController.view.isDescendant(of: coordinator.containerView)
-    {
-      coordinator.animate(alongsideTransition: nil, completion: { _ in
+    if let apply = configuration.applyBarModels {
+      apply {
         container.setBars(models, animated: animated)
-      })
+      }
     } else {
       container.setBars(models, animated: animated)
     }

--- a/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
@@ -10,8 +10,10 @@ public struct BarInstallerConfiguration {
 
   // MARK: Lifecycle
 
-  public init(applyBarModels: ((_ apply: () -> Void) -> Void)? = nil) {
-    self.applyBarModels = applyBarModels
+  public init(
+    applyBars: ((_ container: BarContainer, _ bars: [BarModeling], _ animated: Bool) -> Void)? = nil)
+  {
+    self.applyBars = applyBars
   }
 
   // MARK: Public
@@ -34,6 +36,6 @@ public struct BarInstallerConfiguration {
   /// `BarContainer`.
   ///
   /// Not calling the provided `apply` closure will result in skipped bar model updates.
-  public var applyBarModels: ((_ apply: () -> Void) -> Void)?
+  public var applyBars: ((_ container: BarContainer, _ bars: [BarModeling], _ animated: Bool) -> Void)?
 
 }

--- a/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
@@ -1,0 +1,39 @@
+// Created by eric_horacek on 9/1/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+/// A singleton that enables consumers to control how bar installers' internal implementations
+/// behave across the entire app, without needing to update every place that uses it.
+///
+/// Can additionally be provided when initializing a bar installer to customize the behavior of
+/// that specific instance.
+public struct BarInstallerConfiguration {
+
+  // MARK: Lifecycle
+
+  public init(applyBarModels: ((_ apply: () -> Void) -> Void)? = nil) {
+    self.applyBarModels = applyBarModels
+  }
+
+  // MARK: Public
+
+  /// The default configuration instance used if none is provided when initializing a bar installer.
+  ///
+  /// Set this to a new instance to override the default configuration.
+  public static var shared = BarInstallerConfiguration()
+
+  /// A closure that's invoked whenever new bar models are set on a `BarInstaller` following its
+  /// initial configuration to customize _when_ those same bars are applied to the underlying
+  /// `BarContainer` by invoking the provided `apply` closure.
+  ///
+  /// For example, when the bar installer is actively participating in a shared element transition,
+  /// this property can be used to wait until the transition is over before apply the bar models to
+  /// the underlying `BarContainer` to ensure that the shared bar elements remain constant over the
+  /// course of the transition.
+  ///
+  /// Defaults to `nil`, resulting in any new bars being immediately applied to the underlying
+  /// `BarContainer`.
+  ///
+  /// Not calling the provided `apply` closure will result in skipped bar model updates.
+  public var applyBarModels: ((_ apply: () -> Void) -> Void)?
+
+}

--- a/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarInstallerConfiguration.swift
@@ -25,17 +25,17 @@ public struct BarInstallerConfiguration {
 
   /// A closure that's invoked whenever new bar models are set on a `BarInstaller` following its
   /// initial configuration to customize _when_ those same bars are applied to the underlying
-  /// `BarContainer` by invoking the provided `apply` closure.
+  /// `BarContainer`.
   ///
-  /// For example, when the bar installer is actively participating in a shared element transition,
-  /// this property can be used to wait until the transition is over before apply the bar models to
-  /// the underlying `BarContainer` to ensure that the shared bar elements remain constant over the
-  /// course of the transition.
+  /// For example, if the bar installer is actively participating in a shared element transition,
+  /// this property can be used to defer bar updates until the transition is over to ensure that the
+  /// shared bar elements remain constant over the course of the transition.
   ///
   /// Defaults to `nil`, resulting in any new bars being immediately applied to the underlying
   /// `BarContainer`.
   ///
-  /// Not calling the provided `apply` closure will result in skipped bar model updates.
+  /// Not calling `setBars` on the given `BarContainer` with the provided bars will result in
+  /// skipped bar model updates.
   public var applyBars: ((_ container: BarContainer, _ bars: [BarModeling], _ animated: Bool) -> Void)?
 
 }

--- a/Sources/EpoxyBars/BarInstaller/BarStackView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarStackView.swift
@@ -146,8 +146,8 @@ public class BarStackView: UIStackView, EpoxyableView {
 
   /// Updates the contents of this stack to the stack modeled by the given model array, inserting,
   /// removing, and updating any bars as needed.
-  public func setBars(_ models: [BarModeling], animated: Bool) {
-    let updates = updateModels(models, animated: animated)
+  public func setBars(_ bars: [BarModeling], animated: Bool) {
+    let updates = updateModels(bars, animated: animated)
 
     updateWrapperZOrder()
 

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
@@ -21,11 +21,12 @@ public final class BottomBarInstaller: NSObject {
   public init(
     viewController: UIViewController,
     avoidsKeyboard: Bool = false,
-    bars: [BarModeling] = [])
+    bars: [BarModeling] = [],
+    configuration: BarInstallerConfiguration = .shared)
   {
     self.viewController = viewController
     keyboardPositionWatcher.enabled = avoidsKeyboard
-    installer = .init(viewController: viewController)
+    installer = .init(viewController: viewController, configuration: configuration)
     super.init()
     installer.setBars(bars, animated: false)
   }

--- a/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
+++ b/Sources/EpoxyBars/Keyboard/InputAccessoryBarStackView.swift
@@ -43,8 +43,6 @@ public final class InputAccessoryBarStackView: UIView {
 
   public let barStack: BarStackView
 
-  // MARK: UIView
-
   public override var intrinsicContentSize: CGSize {
     barStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
   }

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
@@ -17,9 +17,13 @@ public final class TopBarInstaller: NSObject {
 
   // MARK: Lifecycle
 
-  public init(viewController: UIViewController, bars: [BarModeling] = []) {
+  public init(
+    viewController: UIViewController,
+    bars: [BarModeling] = [],
+    configuration: BarInstallerConfiguration = .shared)
+  {
     self.viewController = viewController
-    installer = .init(viewController: viewController)
+    installer = .init(viewController: viewController, configuration: configuration)
     super.init()
 
     // We don't call `setNeedsStatusBarAppearanceUpdate` through `self.setBars(...)` here since it

--- a/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BaseBarInstallerSpec.swift
@@ -13,7 +13,7 @@ protocol BaseBarInstallerSpec {
   func installBarContainer(
     in viewController: UIViewController,
     configuration: BarInstallerConfiguration)
-    -> (container: InternalBarContainer, setBars: ([BarModeling]) -> Void)
+    -> (container: InternalBarContainer, setBars: ([BarModeling], Bool) -> Void)
 }
 
 // MARK: Spec implementation
@@ -26,7 +26,7 @@ extension BaseBarInstallerSpec {
     var viewController: UIViewController!
     var configuration: BarInstallerConfiguration!
     var container: InternalBarContainer!
-    var setBars: (([BarModeling]) -> Void)!
+    var setBars: (([BarModeling], Bool) -> Void)!
 
     beforeEach {
       window = SafeAreaWindow(
@@ -56,22 +56,22 @@ extension BaseBarInstallerSpec {
       context("with a 100pt bar") {
         it("sets 100pt inset when using .barHeightSafeArea") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
         }
 
         it("updates to 200pt inset when updating bar height") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
 
-          setBars([StaticHeightBar.barModel(style: .init(height: 200 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 200 + defaultSafeAreaInset))], false)
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(200))
         }
 
         it("doesn't override custom inset when using .none") {
           container.insetBehavior = .none
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(0))
 
           viewController.additionalSafeAreaInsets[keyPath: container.position.inset] = 50
@@ -80,7 +80,7 @@ extension BaseBarInstallerSpec {
 
         it("sets inset to 0 when changing from .barHeightSafeArea to .none") {
           container.insetBehavior = .barHeightSafeArea
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(viewController.additionalSafeAreaInsets[keyPath: container.position.inset]).toEventually(equal(100))
 
           container.insetBehavior = .none
@@ -89,19 +89,19 @@ extension BaseBarInstallerSpec {
 
         it("sets layout margins when insetMargins=true") {
           container.insetMargins = true
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(defaultSafeAreaInset))
         }
 
         it("doesn't set layout margins when insetMargins=false") {
           container.insetMargins = false
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(0))
         }
 
         it("clears layout margins when changing from insetMargins=true to insetMargins=true") {
           container.insetMargins = true
-          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))])
+          setBars([StaticHeightBar.barModel(style: .init(height: 100 + defaultSafeAreaInset))], false)
           expect(container.layoutMargins[keyPath: container.position.inset]).toEventually(equal(defaultSafeAreaInset))
 
           container.insetMargins = false
@@ -111,37 +111,58 @@ extension BaseBarInstallerSpec {
     }
 
     describe("BarInstallerConfiguration") {
-      context("with a non-nil applyBarModels") {
-        var didApply: Bool!
+      context("with a non-nil applyBars") {
+        var applications: [(container: BarContainer, bars: [BarModeling], animated: Bool)]!
 
         beforeEach {
-          didApply = false
+          applications = []
 
-          configuration = BarInstallerConfiguration(applyBarModels: { apply in
-            didApply = true
-            apply()
+          configuration = BarInstallerConfiguration(applyBars: { container, bars, animated in
+            applications.append((container, bars, animated))
+            container.setBars(bars, animated: animated)
           })
 
           (container, setBars) = self.installBarContainer(in: viewController, configuration: configuration)
         }
 
         afterEach {
-          didApply = nil
+          applications = nil
         }
 
         context("with the initial bars") {
-          it("should not call the applyBarModels closure") {
-            expect(didApply) == false
+          it("should not call the applyBars closure") {
+            expect(applications).to(haveCount(0))
+          }
+
+          it("should not have applied any bars") {
+            expect(container.barViews).to(haveCount(0))
           }
         }
 
         context("when setting subsequent bars") {
+          let bars = [StaticHeightBar.barModel(style: .init(height: 100))]
+          let animated = false
+
           beforeEach {
-            setBars([StaticHeightBar.barModel(style: .init(height: 100))])
+            setBars(bars, animated)
           }
 
-          it("should call the applyBarModels closure") {
-            expect(didApply) == true
+          it("should call the applyBars closure") {
+            expect(applications).to(haveCount(1))
+          }
+
+          it("should call the applyBars closure with the container") {
+            expect(applications.first?.container) === container
+          }
+
+          it("should call the applyBars closure with the animated value") {
+            expect(applications.first?.animated) == animated
+          }
+
+          it("should call the applyBars closure with the bars value") {
+            let appliedBar = applications.first?.bars.first?.eraseToAnyBarModel()
+            let bar = bars.first
+            expect(appliedBar?.diffIdentifier) == bar?.diffIdentifier
           }
 
           it("should apply the bars") {

--- a/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
@@ -12,7 +12,7 @@ final class BottomBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
   func installBarContainer(
     in viewController: UIViewController,
     configuration: BarInstallerConfiguration)
-    -> (container: InternalBarContainer, setBars: ([BarModeling]) -> Void)
+    -> (container: InternalBarContainer, setBars: ([BarModeling], Bool) -> Void)
   {
     let barInstaller = BottomBarInstaller(viewController: viewController, configuration: configuration)
     viewController.view.layoutIfNeeded()
@@ -20,7 +20,7 @@ final class BottomBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
     return (
       container: barInstaller.container!,
-      setBars: { barInstaller.setBars($0, animated: false) })
+      setBars: { barInstaller.setBars($0, animated: $1) })
   }
 
   override func spec() {

--- a/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
@@ -9,10 +9,12 @@ import UIKit
 
 final class BottomBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
-  func installBarContainer(in viewController: UIViewController)
+  func installBarContainer(
+    in viewController: UIViewController,
+    configuration: BarInstallerConfiguration)
     -> (container: InternalBarContainer, setBars: ([BarModeling]) -> Void)
   {
-    let barInstaller = BottomBarInstaller(viewController: viewController)
+    let barInstaller = BottomBarInstaller(viewController: viewController, configuration: configuration)
     viewController.view.layoutIfNeeded()
     barInstaller.install()
 

--- a/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
@@ -9,10 +9,12 @@ import UIKit
 
 final class TopBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
-  func installBarContainer(in viewController: UIViewController)
+  func installBarContainer(
+    in viewController: UIViewController,
+    configuration: BarInstallerConfiguration)
     -> (container: InternalBarContainer, setBars: ([BarModeling]) -> Void)
   {
-    let barInstaller = TopBarInstaller(viewController: viewController)
+    let barInstaller = TopBarInstaller(viewController: viewController, configuration: configuration)
     viewController.view.layoutIfNeeded()
     barInstaller.install()
 

--- a/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
@@ -12,7 +12,7 @@ final class TopBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
   func installBarContainer(
     in viewController: UIViewController,
     configuration: BarInstallerConfiguration)
-    -> (container: InternalBarContainer, setBars: ([BarModeling]) -> Void)
+    -> (container: InternalBarContainer, setBars: ([BarModeling], Bool) -> Void)
   {
     let barInstaller = TopBarInstaller(viewController: viewController, configuration: configuration)
     viewController.view.layoutIfNeeded()
@@ -20,7 +20,7 @@ final class TopBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
     return (
       container: barInstaller.container!,
-      setBars: { barInstaller.setBars($0, animated: false) })
+      setBars: { barInstaller.setBars($0, animated: $1) })
   }
 
   override func spec() {

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -44,7 +44,7 @@ final class CollectionViewSpec: QuickSpec {
           erasedItemWillDisplay = []
           erasedItemDidEndDisplaying = []
 
-          let section = SectionModel(items: [item])
+          let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [item])
           collectionView.setSections([section], animated: false)
         }
 
@@ -115,7 +115,7 @@ final class CollectionViewSpec: QuickSpec {
           erasedItemWillDisplay = []
           erasedItemDidEndDisplaying = []
 
-          let section = SectionModel(items: [ItemModel(dataID: "dataID")])
+          let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [ItemModel(dataID: "dataID")])
             .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [item])
           collectionView.setSections([section], animated: false)
         }
@@ -176,7 +176,7 @@ final class CollectionViewSpec: QuickSpec {
           var sectionDidEndDisplaying: [SectionModel.CallbackContext]!
 
           beforeEach {
-            let section = SectionModel(items: [itemModel])
+            let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
               .willDisplay { sectionWillDisplay.append($0) }
               .didEndDisplaying { sectionDidEndDisplaying.append($0) }
@@ -309,7 +309,7 @@ final class CollectionViewSpec: QuickSpec {
             didSetBehaviors = []
             erasedItemDidSetBehaviors = []
 
-            section = SectionModel(items: [item])
+            section = SectionModel(dataID: DefaultDataID.noneProvided, items: [item])
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
           }
 
@@ -356,7 +356,7 @@ final class CollectionViewSpec: QuickSpec {
             didSetBehaviorsSupplementary = []
             erasedItemDidSetBehaviorsSupplementary = []
 
-            section = SectionModel(items: [itemModel])
+            section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItem])
           }
 
@@ -407,7 +407,7 @@ final class CollectionViewSpec: QuickSpec {
             didSetContent = []
             erasedItemDidSetContent = []
 
-            let section = SectionModel(items: [item])
+            let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [item])
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
 
             collectionView.setSections([section], animated: false)
@@ -439,7 +439,7 @@ final class CollectionViewSpec: QuickSpec {
             didSetContentSupplementary = []
             erasedItemDidSetContentSupplementary = []
 
-            let section = SectionModel(items: [itemModel])
+            let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
               .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItem])
 
             collectionView.setSections([section], animated: false)
@@ -474,7 +474,7 @@ final class CollectionViewSpec: QuickSpec {
           didChangeState = []
           erasedItemDidChangeState = []
 
-          section = SectionModel(items: [item])
+          section = SectionModel(dataID: DefaultDataID.noneProvided, items: [item])
             .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
           collectionView.setSections([section], animated: false)
           // Required to prevent a index path out of bounds exception during selection.
@@ -523,7 +523,7 @@ final class CollectionViewSpec: QuickSpec {
         itemDidSelect = []
         erasedItemDidSelect = []
 
-        let section = SectionModel(items: [item])
+        let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [item])
           .supplementaryItems(ofKind: UICollectionView.elementKindSectionHeader, [supplementaryItemModel])
         collectionView.setSections([section], animated: false)
         // Required to prevent a index path out of bounds exception during selection.

--- a/Tests/EpoxyTests/CollectionViewTests/FlowLayoutTests.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/FlowLayoutTests.swift
@@ -33,7 +33,7 @@ final class FlowLayoutSpec: QuickSpec {
 
     describe("when the items provide no information") {
       beforeEach {
-        collectionView.setSections([SectionModel(items: [itemModel])], animated: false)
+        collectionView.setSections([SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])], animated: false)
       }
       it("uses the itemSize from the UICollectionViewFlowLayout") {
         let itemSize = collectionView.collectionView(
@@ -87,7 +87,7 @@ final class FlowLayoutSpec: QuickSpec {
     describe("when the items and the sections provide item sizes") {
       beforeEach {
         let itemModel = itemModel.flowLayoutItemSize(.init(width: 5, height: 5))
-        let section = SectionModel(items: [itemModel])
+        let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
           .flowLayoutItemSize(CGSize(width: 6, height: 6))
         collectionView.setSections([section], animated: false)
       }
@@ -103,7 +103,7 @@ final class FlowLayoutSpec: QuickSpec {
 
     describe("when the section provides item sizes") {
       beforeEach {
-        let section = SectionModel(items: [itemModel])
+        let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
           .flowLayoutItemSize(CGSize(width: 6, height: 6))
         collectionView.setSections([section], animated: false)
       }
@@ -119,7 +119,7 @@ final class FlowLayoutSpec: QuickSpec {
 
     describe("when the section models provide values") {
       beforeEach {
-        let section = SectionModel(items: [itemModel])
+        let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
           .flowLayoutSectionInset(.init(top: 7, left: 7, bottom: 7, right: 7))
           .flowLayoutMinimumLineSpacing(8)
           .flowLayoutMinimumInteritemSpacing(9)
@@ -172,7 +172,7 @@ final class FlowLayoutSpec: QuickSpec {
     describe("when the section models provide values and there is a delegate") {
       let layoutDelegate = ProxyDelegate()
       beforeEach {
-        let section = SectionModel(items: [itemModel])
+        let section = SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])
           .flowLayoutSectionInset(.init(top: 7, left: 7, bottom: 7, right: 7))
           .flowLayoutMinimumLineSpacing(8)
           .flowLayoutMinimumInteritemSpacing(9)
@@ -228,7 +228,7 @@ final class FlowLayoutSpec: QuickSpec {
         layout = UICollectionViewFlowLayout()
         collectionView = CollectionView(layout: layout)
         collectionView.frame = CGRect(x: 0, y: 0, width: 350, height: 350)
-        collectionView.setSections([SectionModel(items: [itemModel])], animated: false)
+        collectionView.setSections([SectionModel(dataID: DefaultDataID.noneProvided, items: [itemModel])], animated: false)
       }
       it("uses the default sizes") {
         let itemSize = collectionView.collectionView(


### PR DESCRIPTION
## Change summary
- Adds a new `BarInstallerConfiguration` type to allow both global and per-instance configuration of bar installers.
- Adds an `applyBars` closure to `BarInstallerConfiguration` to allow consumers to configure _when_ bars are applied to the underlying `BarContainer` by a bar installer.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
