### PR TITLE
[EpoxyCollectionView] Fix animated scroll bounds checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bars are applied to the underlying `BarContainer` by a bar installer, e.g. to defer bar model
   updates that might conflict with an in-flight shared element transition.
 
+### Fixed
+- Fixes an issue that could cause `CollectionView` scroll animation frames to have an incorrect
+  content offset when paired with a non-zero `adjustedContentInset`.
+
 ### Changed
 - Removed the default bar installer behavior where bar model updates were deferred while a view
   controller transition is in progress.

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
@@ -137,8 +137,9 @@ final class CollectionViewScrollToItemHelper {
     self.scrollToItemDisplayLink = scrollToItemDisplayLink
   }
 
-  /// Removes our scroll-to-item context and finalizes our custom scroll-to-item by invoking the original function. This guarantees that
-  /// our last frame of animation ends us in the correct position.
+  /// Removes our scroll-to-item context and finalizes our custom scroll-to-item by invoking the
+  /// original function. This guarantees that our last frame of animation ends us in the correct
+  /// position.
   private func finalizeScrollingTowardItem(
     for scrollToItemContext: ScrollToItemContext,
     animated: Bool)
@@ -194,18 +195,13 @@ final class CollectionViewScrollToItemHelper {
     let positionBeforeLayout = positionRelativeToVisibleBounds(
       forTargetItemIndexPath: scrollToItemContext.targetIndexPath,
       collectionView: collectionView)
+
     switch positionBeforeLayout {
     case .before:
-      switch scrollAxis {
-      case .vertical: collectionView.contentOffset.y -= offset
-      case .horizontal: collectionView.contentOffset.x -= offset
-      }
+      collectionView.contentOffset[scrollAxis] -= offset
 
     case .after:
-      switch scrollAxis {
-      case .vertical: collectionView.contentOffset.y += offset
-      case .horizontal: collectionView.contentOffset.x += offset
-      }
+      collectionView.contentOffset[scrollAxis] += offset
 
     // If the target item is partially or fully visible, then we don't need to apply a full `offset`
     // adjustment of the content offset. Instead, we do some special logic to look at how close we
@@ -278,8 +274,8 @@ final class CollectionViewScrollToItemHelper {
     return offset * 1.5
   }
 
-  // Returns the position (before, after, visible) of an item relative to the current viewport.
-  // Note that the position (before, after, visible) is agnostic of scroll axis.
+  /// Returns the position (before, after, visible) of an item relative to the current viewport.
+  /// Note that the position (before, after, visible) is agnostic of scroll axis.
   private func positionRelativeToVisibleBounds(
     forTargetItemIndexPath targetIndexPath: IndexPath,
     collectionView: UICollectionView)
@@ -306,9 +302,9 @@ final class CollectionViewScrollToItemHelper {
     }
   }
 
-  // If a scroll position is not specified, this function is called to find the closest scroll
-  // position to make the item as visible as possible. If the item is already completely visible,
-  // this function returns `nil`.
+  /// If a scroll position is not specified, this function is called to find the closest scroll
+  /// position to make the item as visible as possible. If the item is already completely visible,
+  /// this function returns `nil`.
   private func closestRestingScrollPosition(
     forTargetItemIndexPath targetIndexPath: IndexPath,
     collectionView: UICollectionView)
@@ -345,9 +341,10 @@ final class CollectionViewScrollToItemHelper {
     }
   }
 
-  // Returns the correct resting position for a scroll-to-item action for the current viewport.
-  // This will be used to determine how much farther we need to programmatically scroll on each
-  // animation tick.
+  /// Returns the correct content offset for a scroll-to-item action for the current viewport.
+  ///
+  /// This will be used to determine how much farther we need to programmatically scroll on each
+  /// animation tick.
   private func targetContentOffsetForVisibleItem(
     withFrame itemFrame: CGRect,
     inBounds bounds: CGRect,
@@ -357,20 +354,18 @@ final class CollectionViewScrollToItemHelper {
     scrollAxis: ScrollAxis)
     -> CGPoint
   {
-    let itemPosition, itemSize, contentOffset, viewportSize, minContentOffset, maxContentOffset: CGFloat
+    let itemPosition, itemSize, viewportSize, minContentOffset, maxContentOffset: CGFloat
     let visibleBounds = bounds.inset(by: adjustedContentInset)
     switch scrollAxis {
     case .vertical:
       itemPosition = itemFrame.minY
       itemSize = itemFrame.height
-      contentOffset = bounds.minY
       viewportSize = visibleBounds.height
       minContentOffset = -adjustedContentInset.top
       maxContentOffset = -adjustedContentInset.top + contentSize.height - visibleBounds.height
     case .horizontal:
       itemPosition = itemFrame.minX
       itemSize = itemFrame.width
-      contentOffset = bounds.minX
       viewportSize = visibleBounds.width
       minContentOffset = -adjustedContentInset.left
       maxContentOffset = -adjustedContentInset.left + contentSize.width - visibleBounds.width
@@ -424,7 +419,7 @@ private enum PositionRelativeToVisibleBounds {
 // MARK: - CGPoint
 
 extension CGPoint {
-  fileprivate subscript(_ axis: ScrollAxis) -> CGFloat {
+  fileprivate subscript(axis: ScrollAxis) -> CGFloat {
     get {
       switch axis {
       case .vertical: return y

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
@@ -214,7 +214,7 @@ final class CollectionViewScrollToItemHelper {
     case .partiallyOrFullyVisible(let frame):
       let targetOrigin = targetOriginForVisibleItem(
         withFrame: frame,
-        inVisibleBounds: collectionView.bounds,
+        inVisibleBounds: collectionView.bounds.inset(by: collectionView.adjustedContentInset),
         targetScrollPosition: scrollToItemContext.targetScrollPosition,
         scrollAxis: scrollAxis)
       let targetPosition: CGFloat


### PR DESCRIPTION
## Change summary
When we're scrolling to the item we should calculate the visible bounds using the `adjustedContentInset`. If we don't do this, the returned target origin is incorrect as it doesn't account for the safe area or content insets.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
