### PR TITLE
Lower bottom constraint priority for VGroupView and HGroupView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixes an issue that could cause `CollectionView` scroll animation frames to have an incorrect
   content offset when paired with a non-zero `adjustedContentInset`.
+- Fixes an issue that could cause `VGroupView` and `HGroupView` to grow too tall when nested in
+  containers that give them a larger height than their natural height.
 
 ### Changed
 - Removed the default bar installer behavior where bar model updates were deferred while a view

--- a/Sources/EpoxyLayoutGroups/Views/HGroupView.swift
+++ b/Sources/EpoxyLayoutGroups/Views/HGroupView.swift
@@ -19,7 +19,17 @@ public final class HGroupView: UIView, EpoxyableView {
     translatesAutoresizingMaskIntoConstraints = false
     updateLayoutMargins()
     hGroup.install(in: self)
-    hGroup.constrainToMarginsWithHighPriorityBottom()
+
+    let bottom = hGroup.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+    // using a low priority allows the HGroup to hug closely to the content
+    // on the vertical axis which is how UIStackView behaves
+    bottom.priority = .defaultLow
+    NSLayoutConstraint.activate([
+      hGroup.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      hGroup.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+      hGroup.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      bottom,
+    ])
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/EpoxyLayoutGroups/Views/VGroupView.swift
+++ b/Sources/EpoxyLayoutGroups/Views/VGroupView.swift
@@ -19,7 +19,17 @@ public final class VGroupView: UIView, EpoxyableView {
     translatesAutoresizingMaskIntoConstraints = false
     updateLayoutMargins()
     vGroup.install(in: self)
-    vGroup.constrainToMarginsWithHighPriorityBottom()
+
+    let bottom = vGroup.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+    // using a low priority allows the VGroup to hug closely to the content
+    // on the vertical axis which is how UIStackView behaves
+    bottom.priority = .defaultLow
+    NSLayoutConstraint.activate([
+      vGroup.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      vGroup.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+      vGroup.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      bottom,
+    ])
   }
 
   required init?(coder: NSCoder) {


### PR DESCRIPTION
## Change summary
This PR lowers the bottom constraint priority on VGroupView and HGroupView's internal groups. The reason we do this is to allow the VGroupView to grow larger than the internal VGroup it contains. This is how UIStackView works as well where the content within the stack can be shorter than the size of the stack itself and results in much nicer looking layouts.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
