### PR TITLE
[SwiftUI] Add clear background color to EpoxySwiftUIHostingController

### DIFF
--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -26,6 +26,18 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
     }
   }
 
+  // MARK: Open
+
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+
+    // A `UIHostingController` has a system background color by default as it's typically used in
+    // full-screen use cases. Since we're using this view controller to place SwiftUI views within
+    // other view controllers we default the background color to clear so we can see the views
+    // below, e.g. to draw highlight states in a `CollectionView`.
+    view.backgroundColor = .clear
+  }
+
   // MARK: Private
 
   /// Creates a dynamic subclass of this hosting controller's view that ignores its safe area


### PR DESCRIPTION
## Change summary
A `UIHostingController` has a system background color by default as it's typically used in full-screen use cases. Since we're using this view controller to place SwiftUI views within other view controllers we default the background color to clear so we can see the views below, e.g. to draw highlight states in a `CollectionView`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
