### PR TITLE
Give BottomBarContainer a weak reference to its BottomBarInstaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.6.0...HEAD)
-- Added a weak reference from `BottomBarContainer` to its parent `BottomBarInstaller`
+- Added a weak reference from `TopBarContainer` / `BottomBarContainer` to their parent bar installer
 
 ### Added
 - Added a `BarInstallerConfiguration` type to allow both global and per-instance configuration of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.6.0...HEAD)
+- Added a weak reference from `BottomBarContainer` to its parent `BottomBarInstaller`
 
 ### Added
 - Added a `BarInstallerConfiguration` type to allow both global and per-instance configuration of

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -66,6 +66,9 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
     }
   }
 
+  /// The `BottomBarInstaller` that manages this `BottomBarContainer`
+  public internal(set) weak var barInstaller: BottomBarInstaller?
+
   public override func layoutSubviews() {
     super.layoutSubviews()
     updateInsets()

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -28,6 +28,9 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
 
   // MARK: Public
 
+  /// The `BottomBarInstaller` that manages this `BottomBarContainer`
+  public internal(set) weak var barInstaller: BottomBarInstaller?
+
   public override var center: CGPoint {
     didSet {
       guard center != oldValue else { return }
@@ -65,9 +68,6 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
       viewController?.view.layoutIfNeeded()
     }
   }
-
-  /// The `BottomBarInstaller` that manages this `BottomBarContainer`
-  public internal(set) weak var barInstaller: BottomBarInstaller?
 
   public override func layoutSubviews() {
     super.layoutSubviews()

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarInstaller.swift
@@ -75,12 +75,14 @@ public final class BottomBarInstaller: NSObject {
   /// installation or if a bar model was set prior to installation.
   public func install() {
     installer.install()
+    container?.barInstaller = self
     watchKeyboardPosition(true)
   }
 
   /// Removes the bar stack from the associated view controller.
   public func uninstall() {
     installer.uninstall()
+    container?.barInstaller = nil
     watchKeyboardPosition(false)
   }
 

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -33,6 +33,9 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
     case hidden(roomToReappear: Bool)
   }
 
+  /// The `TopBarInstaller` that manages this `TopBarContainer`
+  public internal(set) weak var barInstaller: TopBarInstaller?
+
   public override var center: CGPoint {
     didSet {
       guard center != oldValue else { return }

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarInstaller.swift
@@ -69,11 +69,13 @@ public final class TopBarInstaller: NSObject {
   /// installation or if a bar model was set prior to installation.
   public func install() {
     installer.install()
+    container?.barInstaller = self
   }
 
   /// Removes the bar stack from the associated view controller.
   public func uninstall() {
     installer.uninstall()
+    container?.barInstaller = nil
   }
 
   // MARK: Internal

--- a/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/BottomBarInstallerSpec.swift
@@ -25,6 +25,20 @@ final class BottomBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
   override func spec() {
     baseSpec()
+
+    describe("BottomBarContainer") {
+      it("has a reference to the BottomBarInstaller when installed") {
+        let viewController = UIViewController()
+        viewController.loadView()
+        let barInstaller = BottomBarInstaller(viewController: viewController)
+
+        barInstaller.install()
+        expect(barInstaller.container?.barInstaller).toEventually(equal(barInstaller))
+
+        barInstaller.uninstall()
+        expect(barInstaller.container?.barInstaller).toEventually(beNil())
+      }
+    }
   }
 
 }

--- a/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
+++ b/Tests/EpoxyTests/BarsTests/TopBarInstallerSpec.swift
@@ -25,6 +25,20 @@ final class TopBarInstallerSpec: QuickSpec, BaseBarInstallerSpec {
 
   override func spec() {
     baseSpec()
+
+    describe("TopBarContainer") {
+      it("has a reference to the TopBarInstaller when installed") {
+        let viewController = UIViewController()
+        viewController.loadView()
+        let barInstaller = TopBarInstaller(viewController: viewController)
+
+        barInstaller.install()
+        expect(barInstaller.container?.barInstaller).toEventually(equal(barInstaller))
+
+        barInstaller.uninstall()
+        expect(barInstaller.container?.barInstaller).toEventually(beNil())
+      }
+    }
   }
 
 }


### PR DESCRIPTION
## Change summary

This PR gives `BottomBarContainer` a `weak` reference to its `BottomBarInstaller`. This lets us access the `BottomBarInstaller` from extensions that add behavior to the `BottomBarContainer`.

## How was it tested?
- [x] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
