### PR TITLE
Fix KeyboardPositionWatcher dismissal logic with offscreen views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   content offset when paired with a non-zero `adjustedContentInset`.
 - Fixes an issue that could cause `VGroupView` and `HGroupView` to grow too tall when nested in
   containers that give them a larger height than their natural height.
+- Fixes a bug in the `KeyboardPositionWatcher` that would consider an even slightly offscreen view
+  as having a keyboard overlap when the keyboard is dismissed, resulting in incorrect keyboard
+  offsets.
 
 ### Changed
 - Removed the default bar installer behavior where bar model updates were deferred while a view

--- a/Sources/EpoxyBars/Keyboard/KeyboardPositionWatcher.swift
+++ b/Sources/EpoxyBars/Keyboard/KeyboardPositionWatcher.swift
@@ -130,7 +130,7 @@ public class KeyboardPositionWatcher {
       return
     }
 
-    let screen = UIScreen.main.coordinateSpace
+    let screen = UIScreen.main
 
     for (view, observer) in observers {
       let overlap = self.overlap(for: view, keyboardFrame: keyboardFrame, in: screen)
@@ -142,10 +142,14 @@ public class KeyboardPositionWatcher {
   private func overlap(
     for view: UIView,
     keyboardFrame: CGRect,
-    in coordinateSpace: UICoordinateSpace)
+    in screen: UIScreen)
     -> CGFloat
   {
-    let keyboardFrameInView = coordinateSpace.convert(keyboardFrame, to: view)
+    // If the keyboard is offscreen (hidden), always consider it to have a zero overlap to ensure we
+    // don't consider slightly offscreen views as still having keyboard overlap.
+    guard keyboardFrame.intersects(screen.bounds) else { return 0 }
+
+    let keyboardFrameInView = screen.coordinateSpace.convert(keyboardFrame, to: view)
     let viewBounds = view.bounds
     let intersection = viewBounds.intersection(keyboardFrameInView)
 


### PR DESCRIPTION
## Change summary
Fixes a bug in the `KeyboardPositionWatcher` that would consider an even slightly offscreen view as having a keyboard overlap when the keyboard is dismissed, resulting in incorrect keyboard offsets.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
