### PR TITLE
Allow SwiftUI transactions and size invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   item in a collection view.
 - Added `itemModel(…)`, `barModel(…)` methods to host a SwiftUI `View` within an Epoxy container and
   the `swiftUIView(…)` method to host an `EpoxyableView` within a SwiftUI `View`
+- Added a SwiftUI environment value for requesting size invalidation of the containing Epoxy collection view cell.
 
 ### Fixed
 - Fixes an issue that could cause `CollectionView` scroll animation frames to have an incorrect
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug in the `KeyboardPositionWatcher` that would consider an even slightly offscreen view
   as having a keyboard overlap when the keyboard is dismissed, resulting in incorrect keyboard
   offsets.
+- Fixes an issue when mutating state synchronously does not pick up the current SwiftUI transaction.
 
 ### Changed
 - Removed the default bar installer behavior where bar model updates were deferred while a view

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -71,8 +71,7 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
 
     super.init(frame: .zero)
 
-    epoxyEnvironment.epoxyIntrinsicContentSizeInvalidator = .init(invalidate: {
-      [weak self] in
+    epoxyEnvironment.intrinsicContentSizeInvalidator = .init(invalidate: { [weak self] in
       self?.viewController.view.invalidateIntrinsicContentSize()
     })
     layoutMargins = .zero
@@ -130,6 +129,8 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
   }
 
   public func setContent(_ content: Content, animated: Bool) {
+    /// This triggers a change in the observed `EpoxyHostingContent` object and allows the
+    /// propagation of the SwiftUI transaction, instead of just replacing the `rootView`.
     epoxyContent.rootView = content.rootView
     dataID = content.dataID ?? DefaultDataID.noneProvided as AnyHashable
 
@@ -337,7 +338,7 @@ final class EpoxyHostingContent<RootView: View>: ObservableObject {
 /// `EpoxySwiftUIHostingController`, e.g. layout margins.
 final class EpoxyHostingEnvironment: ObservableObject {
   @Published var layoutMargins = EdgeInsets()
-  @Published var epoxyIntrinsicContentSizeInvalidator = EpoxyIntrinsicContentSizeInvalidator(invalidate: {})
+  @Published var intrinsicContentSizeInvalidator = EpoxyIntrinsicContentSizeInvalidator(invalidate: {})
 }
 
 // MARK: - EpoxyHostingWrapper
@@ -351,6 +352,6 @@ struct EpoxyHostingWrapper<Content: View>: View {
   var body: some View {
     content.rootView
       .environment(\.epoxyLayoutMargins, environment.layoutMargins)
-      .environment(\.epoxyIntrinsicContentSizeInvalidator, environment.epoxyIntrinsicContentSizeInvalidator)
+      .environment(\.epoxyIntrinsicContentSizeInvalidator, environment.intrinsicContentSizeInvalidator)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
@@ -5,8 +5,8 @@ import SwiftUI
 
 // MARK: - EpoxyIntrinsicContentSizeInvalidator
 
-/// Allows the SwiftUI view contained in an Epoxy collection view cell to request
-/// invalidation of the cell's intrinsic content size.
+/// Allows the SwiftUI view contained in an Epoxy model to request the invalidation of
+/// the container's intrinsic content size.
 ///
 /// ```
 /// @Environment(\.epoxyIntrinsicContentSizeInvalidator) var invalidateIntrinsicContentSize

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
@@ -1,0 +1,43 @@
+// Created by matthew_cheok on 11/19/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import SwiftUI
+
+// MARK: - EpoxyIntrinsicContentSizeInvalidator
+
+/// Allows the SwiftUI view contained in an Epoxy collection view cell to request
+/// invalidation of the cell's intrinsic content size.
+///
+/// ```
+/// @Environment(\.epoxyIntrinsicContentSizeInvalidator) var invalidateIntrinsicContentSize
+///
+/// var body: some View {
+///   ...
+///   .onChange(of: size) {
+///     invalidateIntrinsicContentSize()
+///   }
+/// }
+/// ```
+public struct EpoxyIntrinsicContentSizeInvalidator {
+  let invalidate: () -> Void
+
+  public func callAsFunction() {
+    invalidate()
+  }
+}
+
+// MARK: - EnvironmentValues
+
+extension EnvironmentValues {
+  /// A means of invalidating the intrinsic content size of the parent `EpoxySwiftUIHostingView`.
+  public var epoxyIntrinsicContentSizeInvalidator: EpoxyIntrinsicContentSizeInvalidator {
+    get { self[EpoxyIntrinsicContentSizeInvalidatorKey.self] }
+    set { self[EpoxyIntrinsicContentSizeInvalidatorKey.self] = newValue }
+  }
+}
+
+// MARK: - EpoxyIntrinsicContentSizeInvalidatorKey
+
+private struct EpoxyIntrinsicContentSizeInvalidatorKey: EnvironmentKey {
+  static let defaultValue = EpoxyIntrinsicContentSizeInvalidator(invalidate: {})
+}


### PR DESCRIPTION
## Change summary

This change allows for transaction animations if state is mutated synchronously and allows SwiftUI components within epoxy to request size invalidation.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
