### PR TITLE
Update to Swift 5.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
+- Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/ConfigurePodspec.rb
+++ b/ConfigurePodspec.rb
@@ -14,7 +14,7 @@ def configure(spec:, name:, summary:, local_deps: [])
   spec.source = { git: 'https://github.com/airbnb/epoxy-ios.git', tag: version }
   spec.source_files = "Sources/#{name}/**/*.swift"
   spec.ios.deployment_target = '13.0'
-  spec.swift_versions = ['5.3']
+  spec.swift_versions = ['5.4']
 
   local_deps.each do |dep|
     spec.dependency dep, version

--- a/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
-          "version": "3.0.0"
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "e491a6731307bb23783bf664d003be9b2fa59ab5",
-          "version": "9.0.0"
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
-          "version": "3.0.0"
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -16,7 +16,7 @@ let package = Package(
     .library(name: "EpoxyLayoutGroups", targets: ["EpoxyLayoutGroups"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+    .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
   ],
   targets: [

--- a/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
+++ b/Sources/EpoxyCore/Model/EpoxyModelArrayBuilder.swift
@@ -1,7 +1,6 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
 /// A generic result builder that enables a DSL for building arrays of Epoxy models.
 @resultBuilder
 public struct EpoxyModelArrayBuilder<Model> {
@@ -47,50 +46,3 @@ public struct EpoxyModelArrayBuilder<Model> {
     components.flatMap { $0 }
   }
 }
-#else
-/// A generic result builder that enables a DSL for building arrays of Epoxy models.
-@_functionBuilder
-public struct EpoxyModelArrayBuilder<Model> {
-  public typealias Expression = Model
-  public typealias Component = [Model]
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    [expression]
-  }
-
-  public static func buildExpression(_ expression: Component) -> Component {
-    expression
-  }
-
-  public static func buildExpression(_ expression: Expression?) -> Component {
-    if let expression = expression {
-      return [expression]
-    }
-    return []
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    children.flatMap { $0 }
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    children ?? []
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    components.flatMap { $0 }
-  }
-}
-#endif

--- a/Sources/EpoxyPresentations/PresentationModelBuilder.swift
+++ b/Sources/EpoxyPresentations/PresentationModelBuilder.swift
@@ -1,7 +1,6 @@
 // Created by eric_horacek on 3/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if swift(>=5.4)
 /// A result builder that enables a DSL for building an optional presentation model.
 ///
 /// For example:
@@ -68,71 +67,3 @@ public struct PresentationModelBuilder {
     return nil
   }
 }
-#else
-/// A result builder that enables a DSL for building an optional presentation model.
-///
-/// For example:
-/// ```
-/// @PresentationModelBuilder var presentation: PresentationModel? {
-///    if showA {
-///      PresentationModel(…)
-///    }
-///    if showB {
-///      PresentationModel(…)
-///    }
-/// }
-/// ```
-///
-/// Will return a `nil` presentation model if `showA` and `showB` are false, else will return the
-/// first non-`nil` presentation model.
-@_functionBuilder
-public struct PresentationModelBuilder {
-  public typealias Expression = PresentationModel
-  public typealias Component = PresentationModel?
-
-  public static func buildExpression(_ expression: Expression) -> Component {
-    expression
-  }
-
-  public static func buildExpression(_ expression: Component) -> Component {
-    expression
-  }
-
-  public static func buildBlock(_ children: Component...) -> Component {
-    for child in children {
-      if let child = child {
-        return child
-      }
-    }
-    return nil
-  }
-
-  public static func buildBlock(_ component: Component) -> Component {
-    component
-  }
-
-  public static func buildOptional(_ children: Component?) -> Component {
-    if let child = children {
-      return child
-    }
-    return nil
-  }
-
-  public static func buildEither(first child: Component) -> Component {
-    child
-  }
-
-  public static func buildEither(second child: Component) -> Component {
-    child
-  }
-
-  public static func buildArray(_ components: [Component]) -> Component {
-    for child in components {
-      if let child = child {
-        return child
-      }
-    }
-    return nil
-  }
-}
-#endif

--- a/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
+++ b/Tests/EpoxyTests/CoreTests/EpoxyModelBuilderArraySpec.swift
@@ -142,8 +142,6 @@ final class EpoxyModelBuilderArraySpec: QuickSpec {
       }
     }
 
-    // Result builders only work with for loops in Swift 5.4+
-    #if swift(>=5.4)
     context("with a for loop") {
       it("should include the models in the loop") {
         let builder = BuilderTest {
@@ -154,7 +152,6 @@ final class EpoxyModelBuilderArraySpec: QuickSpec {
         expect(builder.models) == [2, 4, 6, 8, 10]
       }
     }
-    #endif
 
     context("with no models") {
       it("should build an empty array") {

--- a/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
+++ b/Tests/EpoxyTests/PresentationsTests/PresentationModelBuilderSpec.swift
@@ -173,8 +173,6 @@ final class PresentationModelBuilderSpec: QuickSpec {
       }
     }
 
-    // Result builders only work with for loops in Swift 5.4+
-    #if swift(>=5.4)
     context("with a for loop") {
       it("should build the first non-nil presentation") {
         let builder = TestBuilder {
@@ -189,7 +187,6 @@ final class PresentationModelBuilderSpec: QuickSpec {
         expect(builder.model?.dataID as? Int) == 2
       }
     }
-    #endif
 
     context("with no presentation models") {
       it("should build a nil model") {


### PR DESCRIPTION
## Change summary
Swift 5.4 is included with Xcode 12.5, and lower versions of Swift/Xcode will no longer be able to submit to the App Store soon. As such we can bump the Swift version to Swift 5.4 in CocoaPods, SPM, and remove all of the conditional checks in the codebase.

While we're here we also update to the latest versions of the Swift packages we depend on.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ensure CI is successful

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
