### PR TITLE
Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.7.0...HEAD)
 
+### Added
+- Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.
+
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -753,6 +753,29 @@ extension CollectionView: UIScrollViewDelegate {
 extension CollectionView: UICollectionViewDelegate {
 
   public func collectionView(
+    _ collectionView: UICollectionView,
+    targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath,
+    toProposedIndexPath proposedIndexPath: IndexPath)
+    -> IndexPath
+  {
+    guard
+      let reorderingDelegate = reorderingDelegate,
+      let originalItem = epoxyDataSource.data?.item(at: originalIndexPath),
+      let originalSection = epoxyDataSource.data?.section(at: originalIndexPath.section),
+      let proposedItem = epoxyDataSource.data?.item(at: proposedIndexPath),
+      let proposedSection = epoxyDataSource.data?.section(at: proposedIndexPath.section)
+    else { return proposedIndexPath }
+
+    return reorderingDelegate.collectionView(
+      self,
+      shouldMoveItem: originalItem,
+      inSection: originalSection,
+      toDestinationItem: proposedItem,
+      inSection: proposedSection)
+    ? proposedIndexPath : originalIndexPath
+  }
+
+  public func collectionView(
     _: UICollectionView,
     willDisplay cell: UICollectionViewCell,
     forItemAt indexPath: IndexPath)

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -753,7 +753,7 @@ extension CollectionView: UIScrollViewDelegate {
 extension CollectionView: UICollectionViewDelegate {
 
   public func collectionView(
-    _ collectionView: UICollectionView,
+    _: UICollectionView,
     targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath,
     toProposedIndexPath proposedIndexPath: IndexPath)
     -> IndexPath
@@ -764,15 +764,18 @@ extension CollectionView: UICollectionViewDelegate {
       let originalSection = epoxyDataSource.data?.section(at: originalIndexPath.section),
       let proposedItem = epoxyDataSource.data?.item(at: proposedIndexPath),
       let proposedSection = epoxyDataSource.data?.section(at: proposedIndexPath.section)
-    else { return proposedIndexPath }
+    else {
+      return proposedIndexPath
+    }
 
-    return reorderingDelegate.collectionView(
+    let shouldMove = reorderingDelegate.collectionView(
       self,
       shouldMoveItem: originalItem,
       inSection: originalSection,
       toDestinationItem: proposedItem,
       inSection: proposedSection)
-    ? proposedIndexPath : originalIndexPath
+
+    return shouldMove ? proposedIndexPath : originalIndexPath
   }
 
   public func collectionView(

--- a/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
@@ -13,11 +13,13 @@ import UIKit
 /// - SeeAlso: `IsMovableProviding`
 public protocol CollectionViewReorderingDelegate: AnyObject {
 
-  /// Check whether the destination is allowed to move the source item to.
-  /// If `false`, the destination item will be pinned and the interactive item cannot be moved to the destination position.
-  /// Default `true`.
+  /// Returns whether the source item is allowed to move to the proposed destination.
   ///
-  /// Corresponds to `UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:) -> IndexPath`
+  /// If `false`, the destination item will be pinned and the interactive item cannot be moved to 
+  /// the destination position. Defaults to `true`.
+  ///
+  /// Corresponds to 
+  /// `UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:)`
   func collectionView(
     _ collectionView: CollectionView,
     shouldMoveItem sourceItem: AnyItemModel,

--- a/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
@@ -3,6 +3,8 @@
 
 import UIKit
 
+// MARK: - CollectionViewReorderingDelegate
+
 /// A delegate that's invoked when the items in a `CollectionView` are moved using the legacy
 /// drag/drop system.
 ///
@@ -15,10 +17,10 @@ public protocol CollectionViewReorderingDelegate: AnyObject {
 
   /// Returns whether the source item is allowed to move to the proposed destination.
   ///
-  /// If `false`, the destination item will be pinned and the interactive item cannot be moved to 
+  /// If `false`, the destination item will be pinned and the interactive item cannot be moved to
   /// the destination position. Defaults to `true`.
   ///
-  /// Corresponds to 
+  /// Corresponds to
   /// `UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:)`
   func collectionView(
     _ collectionView: CollectionView,
@@ -41,11 +43,12 @@ public protocol CollectionViewReorderingDelegate: AnyObject {
 extension CollectionViewReorderingDelegate {
 
   public func collectionView(
-    _ collectionView: CollectionView,
-    shouldMoveItem sourceItem: AnyItemModel,
-    inSection sourceSection: SectionModel,
-    toDestinationItem destinationItem: AnyItemModel,
-    inSection destinationSection: SectionModel) -> Bool
+    _: CollectionView,
+    shouldMoveItem _: AnyItemModel,
+    inSection _: SectionModel,
+    toDestinationItem _: AnyItemModel,
+    inSection _: SectionModel)
+    -> Bool
   {
     true
   }

--- a/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Delegates/CollectionViewReorderingDelegate.swift
@@ -12,6 +12,19 @@ import UIKit
 ///
 /// - SeeAlso: `IsMovableProviding`
 public protocol CollectionViewReorderingDelegate: AnyObject {
+
+  /// Check whether the destination is allowed to move the source item to.
+  /// If `false`, the destination item will be pinned and the interactive item cannot be moved to the destination position.
+  /// Default `true`.
+  ///
+  /// Corresponds to `UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:) -> IndexPath`
+  func collectionView(
+    _ collectionView: CollectionView,
+    shouldMoveItem sourceItem: AnyItemModel,
+    inSection sourceSection: SectionModel,
+    toDestinationItem destinationItem: AnyItemModel,
+    inSection destinationSection: SectionModel) -> Bool
+
   /// Move the specified item to the given new location.
   ///
   /// Corresponds to `UICollectionViewDataSource.collectionView(_:moveItemAt:to:)`.
@@ -21,4 +34,17 @@ public protocol CollectionViewReorderingDelegate: AnyObject {
     inSection sourceSection: SectionModel,
     toDestinationItem destinationItem: AnyItemModel,
     inSection destinationSection: SectionModel)
+}
+
+extension CollectionViewReorderingDelegate {
+
+  public func collectionView(
+    _ collectionView: CollectionView,
+    shouldMoveItem sourceItem: AnyItemModel,
+    inSection sourceSection: SectionModel,
+    toDestinationItem destinationItem: AnyItemModel,
+    inSection destinationSection: SectionModel) -> Bool
+  {
+    true
+  }
 }


### PR DESCRIPTION
## Change summary
Add a support to check whether the destination is expected when drag and drop an item. 
If the new added method return `false`, it indicates that the destination item will be pinned and cannot be dropped an item.
It is implemented by leveraging `UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:) -> IndexPath`. This delegate method was deprecated in iOS 15, but I didn't implement the modern method due to this repo is still deployed in iOS 14+.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
