### PR TITLE
[SwiftUI] Fix reused UIHostingController sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.
 
+### Fixed
+- Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.
+
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).


### PR DESCRIPTION
## Change summary
As of iOS 15.2, `UIHostingController` now renders updated content asynchronously, and as such this view will get sized incorrectly with the previous content when reused unless we invoke this semi-private API. We couldn't find any other method to get the view to resize synchronously after updating `rootView`, but hopefully this will become a public API soon so we can remove this call.

While we're here, and since SwiftUI has forced our hand to use semi-private APIs, we now migrate to using the `_disableSafeArea` API directly in the `EpoxySwiftUIHostingController`.

### Before

https://user-images.githubusercontent.com/438313/151228722-a9d995bd-f6e0-431e-9e1b-77df40be3905.mp4

### After

https://user-images.githubusercontent.com/438313/151228745-57d8933c-6c33-4fa5-9700-1b276a7400a6.mp4



## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
