### PR TITLE
Fix crash in preferredFrameRateRanges on 15.0 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.
+- Fixed crash in `ScrollToItemHelper` caused by `preferredFrameRateRanges` on devices running iOS 15.0 (this issue is not present in devices on 15.1+)
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewScrollToItemHelper.swift
@@ -133,7 +133,7 @@ final class CollectionViewScrollToItemHelper {
     let scrollToItemDisplayLink = CADisplayLink(
       target: self,
       selector: #selector(scrollToItemDisplayLinkFired))
-    if #available(iOS 15.0, *) {
+    if #available(iOS 15.1, *) {
       #if swift(>=5.5) // Proxy check for being built with the iOS 14 & below SDK, running on iOS 15.
       scrollToItemDisplayLink.preferredFrameRateRange = CAFrameRateRange(
         minimum: 80,


### PR DESCRIPTION
## Change summary
As title

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
