### PR TITLE
Add CV configuration options to CVVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SwiftUIMeasurementContainer` for calculating the ideal height of a `UIView` for wrapping
   for SwiftUI usage.
 - Added `SwiftUISizingContainer` for handling ideal size and proposed size for a wrapped `UIView`.
-
-### Added
 - Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.
+- Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` initializers.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
+++ b/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
@@ -77,7 +77,7 @@ open class CollectionViewController: UIViewController {
   /// A method that can be overridden by subclasses to initialize a custom `CollectionView` for this
   /// view controller.
   ///
-  /// Returns a `CollectionView` with `layout` by default.
+  /// Returns a `CollectionView` with `layout` and `configuration` by default.
   open func makeCollectionView() -> CollectionView {
     CollectionView(layout: layout, configuration: configuration)
   }

--- a/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
+++ b/Sources/EpoxyCollectionView/ViewControllers/CollectionViewController.swift
@@ -15,9 +15,14 @@ open class CollectionViewController: UIViewController {
 
   /// Initializes a collection view controller and configures its collection view with the provided
   /// layout and sections once the view loads.
-  public init(layout: UICollectionViewLayout, sections: [SectionModel]? = nil) {
+  public init(
+    layout: UICollectionViewLayout,
+    sections: [SectionModel]? = nil,
+    configuration: CollectionViewConfiguration = .shared)
+  {
     self.layout = layout
     initialSections = sections
+    self.configuration = configuration
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -25,18 +30,23 @@ open class CollectionViewController: UIViewController {
   /// layout and a single section containing the given items once the view loads.
   ///
   /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
-  public convenience init(layout: UICollectionViewLayout, items: [ItemModeling]) {
+  public convenience init(
+    layout: UICollectionViewLayout,
+    items: [ItemModeling],
+    configuration: CollectionViewConfiguration = .shared)
+  {
     let section = SectionModel(dataID: DefaultDataID.noneProvided, items: items)
-    self.init(layout: layout, sections: [section])
+    self.init(layout: layout, sections: [section], configuration: configuration)
   }
 
   /// Initializes a collection view controller and configures its collection view with the provided
   /// layout and sections once the view loads.
   public convenience init(
     layout: UICollectionViewLayout,
-    @SectionModelBuilder sections: () -> [SectionModel])
+    @SectionModelBuilder sections: () -> [SectionModel],
+    configuration: CollectionViewConfiguration = .shared)
   {
-    self.init(layout: layout, sections: sections())
+    self.init(layout: layout, sections: sections(), configuration: configuration)
   }
 
   /// Initializes a collection view controller and configures its collection view with the provided
@@ -45,9 +55,10 @@ open class CollectionViewController: UIViewController {
   /// The `SectionModel` containing the items has a data ID of `DefaultDataID.noneProvided`.
   public convenience init(
     layout: UICollectionViewLayout,
-    @ItemModelBuilder items: () -> [ItemModeling])
+    @ItemModelBuilder items: () -> [ItemModeling],
+    configuration: CollectionViewConfiguration = .shared)
   {
-    self.init(layout: layout, items: items())
+    self.init(layout: layout, items: items(), configuration: configuration)
   }
 
   @available(*, unavailable)
@@ -68,7 +79,7 @@ open class CollectionViewController: UIViewController {
   ///
   /// Returns a `CollectionView` with `layout` by default.
   open func makeCollectionView() -> CollectionView {
-    CollectionView(layout: layout)
+    CollectionView(layout: layout, configuration: configuration)
   }
 
   // MARK: Public
@@ -116,6 +127,9 @@ open class CollectionViewController: UIViewController {
   }
 
   // MARK: Private
+
+  /// The configuration used when initializing the `CollectionView`.
+  private let configuration: CollectionViewConfiguration
 
   /// The sections that should be set on the collection view when it loads, else `nil`.
   private var initialSections: [SectionModel]?


### PR DESCRIPTION
## Change summary
This adds the ability to initialize a `CollectionViewController` with a `CollectionViewConfiguration`. Without this change, if a developer wants to provide a custom configuration in a non-global way, they wouldn't be able to use `CollectionViewController`, and instead would need to work with `CollectionView` directly. 

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
