### PR TITLE
[SwiftUI] Support more sizing behaviors in measurement container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SwiftUISizingContainer` for handling ideal size and proposed size for a wrapped `UIView`.
 - Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.
 - Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` initializers.
+- Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
+  a  SwiftUI `View`.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -10,7 +10,8 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
   public static func swiftUIView(
     content: Content,
     style: Style,
-    behaviors: Behaviors? = nil)
+    behaviors: Behaviors? = nil,
+    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
@@ -18,7 +19,8 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
         content: content,
         style: style,
         behaviors: behaviors,
-        context: context)
+        context: context,
+        sizingBehavior: sizingBehavior)
     }
   }
 }
@@ -31,11 +33,16 @@ extension StyledView
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   public static func swiftUIView(
     content: Content,
-    behaviors: Behaviors? = nil)
+    behaviors: Behaviors? = nil,
+    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
-      SwiftUIStylelessEpoxyableView<Self>(content: content, behaviors: behaviors, context: context)
+      SwiftUIStylelessEpoxyableView<Self>(
+        content: content,
+        behaviors: behaviors,
+        context: context,
+        sizingBehavior: sizingBehavior)
     }
   }
 }
@@ -48,11 +55,16 @@ extension StyledView
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   public static func swiftUIView(
     style: Style,
-    behaviors: Behaviors? = nil)
+    behaviors: Behaviors? = nil,
+    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
-      SwiftUIContentlessEpoxyableView<Self>(style: style, behaviors: behaviors, context: context)
+      SwiftUIContentlessEpoxyableView<Self>(
+        style: style,
+        behaviors: behaviors,
+        context: context,
+        sizingBehavior: sizingBehavior)
     }
   }
 }
@@ -65,11 +77,15 @@ extension StyledView
 {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   public static func swiftUIView(
-    behaviors: Behaviors? = nil)
+    behaviors: Behaviors? = nil,
+    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
-      SwiftUIStylelessContentlessEpoxyableView<Self>(behaviors: behaviors, context: context)
+      SwiftUIStylelessContentlessEpoxyableView<Self>(
+        behaviors: behaviors,
+        context: context,
+        sizingBehavior: sizingBehavior)
     }
   }
 }
@@ -78,27 +94,11 @@ extension StyledView
 
 /// A SwiftUI `View` representing an `EpoxyableView`.
 private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
-
-  // MARK: Lifecycle
-
-  init(
-    content: View.Content,
-    style: View.Style,
-    behaviors: View.Behaviors? = nil,
-    context: SwiftUISizingContext)
-  {
-    self.content = content
-    self.style = style
-    self.behaviors = behaviors
-    self.context = context
-  }
-
-  // MARK: Internal
-
   var content: View.Content
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -133,7 +133,11 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
     let uiView = View(style: style)
     uiView.setContent(content, animated: false)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
+    return SwiftUIMeasurementContainer(
+      view: self,
+      uiView: uiView,
+      context: context,
+      sizingBehavior: sizingBehavior)
   }
 }
 
@@ -144,24 +148,10 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
   where
   View.Style == Never
 {
-
-  // MARK: Lifecycle
-
-  init(
-    content: View.Content,
-    behaviors: View.Behaviors? = nil,
-    context: SwiftUISizingContext)
-  {
-    self.content = content
-    self.behaviors = behaviors
-    self.context = context
-  }
-
-  // MARK: Internal
-
   var content: View.Content
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -187,7 +177,11 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
     let uiView = View()
     uiView.setContent(content, animated: false)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
+    return SwiftUIMeasurementContainer(
+      view: self,
+      uiView: uiView,
+      context: context,
+      sizingBehavior: sizingBehavior)
   }
 }
 
@@ -198,20 +192,10 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
   where
   View.Content == Never
 {
-
-  // MARK: Lifecycle
-
-  init(style: View.Style, behaviors: View.Behaviors? = nil, context: SwiftUISizingContext) {
-    self.style = style
-    self.behaviors = behaviors
-    self.context = context
-  }
-
-  // MARK: Internal
-
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     defer {
@@ -235,7 +219,11 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
   func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View(style: style)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
+    return SwiftUIMeasurementContainer(
+      view: self,
+      uiView: uiView,
+      context: context,
+      sizingBehavior: sizingBehavior)
   }
 }
 
@@ -243,19 +231,9 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style` and `Content`.
 private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
-
-  // MARK: Lifecycle
-
-  init(behaviors: View.Behaviors? = nil, context: SwiftUISizingContext) {
-    self.behaviors = behaviors
-    self.context = context
-    self.context = context
-  }
-
-  // MARK: Internal
-
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     wrapper.view = self
@@ -265,6 +243,10 @@ private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UI
   func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View()
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
+    return SwiftUIMeasurementContainer(
+      view: self,
+      uiView: uiView,
+      context: context,
+      sizingBehavior: sizingBehavior)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -11,7 +11,7 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil,
-    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
@@ -20,7 +20,7 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
         style: style,
         behaviors: behaviors,
         context: context,
-        sizingBehavior: sizingBehavior)
+        sizing: sizing)
     }
   }
 }
@@ -34,7 +34,7 @@ extension StyledView
   public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil,
-    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
@@ -42,7 +42,7 @@ extension StyledView
         content: content,
         behaviors: behaviors,
         context: context,
-        sizingBehavior: sizingBehavior)
+        sizing: sizing)
     }
   }
 }
@@ -56,7 +56,7 @@ extension StyledView
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil,
-    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
@@ -64,7 +64,7 @@ extension StyledView
         style: style,
         behaviors: behaviors,
         context: context,
-        sizingBehavior: sizingBehavior)
+        sizing: sizing)
     }
   }
 }
@@ -78,14 +78,14 @@ extension StyledView
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
-    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
     -> some View
   {
     SwiftUISizingContainer { context in
       SwiftUIStylelessContentlessEpoxyableView<Self>(
         behaviors: behaviors,
         context: context,
-        sizingBehavior: sizingBehavior)
+        sizing: sizing)
     }
   }
 }
@@ -98,7 +98,7 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
+  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -137,7 +137,7 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
       view: self,
       uiView: uiView,
       context: context,
-      sizingBehavior: sizingBehavior)
+      sizing: sizing)
   }
 }
 
@@ -151,7 +151,7 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
   var content: View.Content
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
+  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -181,7 +181,7 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
       view: self,
       uiView: uiView,
       context: context,
-      sizingBehavior: sizingBehavior)
+      sizing: sizing)
   }
 }
 
@@ -195,7 +195,7 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
+  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     defer {
@@ -223,7 +223,7 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
       view: self,
       uiView: uiView,
       context: context,
-      sizingBehavior: sizingBehavior)
+      sizing: sizing)
   }
 }
 
@@ -233,7 +233,7 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
 private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
+  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     wrapper.view = self
@@ -247,6 +247,6 @@ private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UI
       view: self,
       uiView: uiView,
       context: context,
-      sizingBehavior: sizingBehavior)
+      sizing: sizing)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -57,16 +57,18 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType>: UIView
     latestMeasuredSize = nil
     super.invalidateIntrinsicContentSize()
   }
-
   public override func layoutSubviews() {
     super.layoutSubviews()
 
-    // We need to re-measure the view whenever the size of the bounds change, as the previous size
-    // will be incorrect.
-    if bounds.size != latestMeasurementBoundsSize {
-      if measureView().changed {
+    switch sizingBehavior {
+    case .intrinsicHeightBoundsWidth, .intrinsicWidthBoundsHeight:
+      // We need to re-measure the view whenever the size of the bounds change and the view is
+      // sized to the bounds size, as the previous size will now be incorrect.
+      if bounds.size != latestMeasurementBoundsSize, measureView().changed {
         super.invalidateIntrinsicContentSize()
       }
+    case .intrinsicSize:
+      break
     }
   }
 

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -115,7 +115,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType>: UIView
   }
 
   /// Measures the `uiView`, returning the resulting size and whether it changed from the previously
-  /// measured size stored it in `latestMeasuredSize`.
+  /// measured size stored in `latestMeasuredSize`.
   @discardableResult
   private func measureView() -> (size: CGSize, changed: Bool) {
     // On the first layout, use the `initialSize` to measure with a reasonable first attempt, as
@@ -185,6 +185,6 @@ public enum SwiftUIMeasurementContainerSizingBehavior {
   /// The `uiView` is sized with its intrinsic width and expands vertically to fill the bounds
   /// offered by its parent.
   case intrinsicWidthBoundsHeight
-  /// The `uiView` is sized to with its intrinsic width and height.
+  /// The `uiView` is sized to its intrinsic width and height.
   case intrinsicSize
 }

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -5,14 +5,14 @@ import SwiftUI
 
 // MARK: - SwiftUIMeasurementContainer
 
-/// A view that has an `intrinsicContentSize` of the `view`'s `systemLayoutSizeFitting(…)` and
+/// A view that has an `intrinsicContentSize` of the `uiView`'s `systemLayoutSizeFitting(…)` and
 /// supports double layout pass sizing and content size category changes.
+///
 /// This container view uses an injected proposed width to measure the view and return its ideal
 /// height through the `SwiftUISizingContext` binding.
-public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType>: UIView
-  where
-  UIViewType: UIView
-{
+///
+/// - SeeAlso: ``SwiftUISizingContainer``
+public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>: UIView {
 
   // MARK: Lifecycle
 

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -63,7 +63,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
     switch sizing {
     case .intrinsicHeightBoundsWidth, .intrinsicWidthBoundsHeight:
-      // We need to re-measure the view whenever the size of the bounds change and the view is
+      // We need to re-measure the view whenever the size of the bounds changes and the view is
       // sized to the bounds size, as the previous size will now be incorrect.
       if bounds.size != latestMeasurementBoundsSize, measureView().changed {
         super.invalidateIntrinsicContentSize()

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -20,12 +20,12 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     view: SwiftUIView,
     uiView: UIViewType,
     context: SwiftUISizingContext,
-    sizingBehavior: SwiftUIMeasurementContainerSizingBehavior)
+    sizing: SwiftUIMeasurementContainerSizing)
   {
     self.view = view
     self.uiView = uiView
     self.context = context
-    self.sizingBehavior = sizingBehavior
+    self.sizing = sizing
     super.init(frame: .zero)
 
     addSubview(uiView)
@@ -57,10 +57,11 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     latestMeasuredSize = nil
     super.invalidateIntrinsicContentSize()
   }
+
   public override func layoutSubviews() {
     super.layoutSubviews()
 
-    switch sizingBehavior {
+    switch sizing {
     case .intrinsicHeightBoundsWidth, .intrinsicWidthBoundsHeight:
       // We need to re-measure the view whenever the size of the bounds change and the view is
       // sized to the bounds size, as the previous size will now be incorrect.
@@ -76,7 +77,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
   private let context: SwiftUISizingContext
 
-  private let sizingBehavior: SwiftUIMeasurementContainerSizingBehavior
+  private let sizing: SwiftUIMeasurementContainerSizing
 
   /// The bounds size at the time of the latest measurement.
   ///
@@ -124,7 +125,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     latestMeasurementBoundsSize = measurementBounds
 
     let targetSize, measuredSize: CGSize
-    switch sizingBehavior {
+    switch sizing {
     case .intrinsicHeightBoundsWidth:
       targetSize = CGSize(
         width: measurementBounds.width,
@@ -175,10 +176,10 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
   }
 }
 
-// MARK: - SwiftUIMeasurementContainerSizingBehavior
+// MARK: - SwiftUIMeasurementContainerSizing
 
 /// The sizing behavior of a `SwiftUIMeasurementContainer`.
-public enum SwiftUIMeasurementContainerSizingBehavior {
+public enum SwiftUIMeasurementContainerSizing {
   /// The `uiView` is sized with its intrinsic height and expands horizontally to fill the bounds
   /// offered by its parent.
   case intrinsicHeightBoundsWidth

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -5,14 +5,17 @@ import SwiftUI
 
 // MARK: - SwiftUISizingContainer
 
-/// A container which reads the proposed SwiftUI layout and passes it a `SwiftUISizingContext`. This
-/// stores ideal size as state in order to configure the view layout as the ideal size is updated
-/// via the `SwiftUISizingContext`.
+/// A container which reads the proposed SwiftUI layout size and passes it via a
+/// ``SwiftUISizingContext`` to its `Content`, which then dictates the ideal size of this view by
+/// updating the context's `idealSize`.
+///
+/// - SeeAlso: ``SwiftUIMeasurementContainer``
 public struct SwiftUISizingContainer<Content: View>: View {
 
   // MARK: Lifecycle
 
-  /// Constructs a `SwiftUISizingContainer` view
+  /// Constructs a `SwiftUISizingContainer` view.
+  ///
   /// - Parameters:
   ///   - estimatedSize: An estimated size used as a placeholder ideal size until view measurement
   ///     occurs. Pass `nil` for this parameter if this container is only used for reading the
@@ -54,8 +57,8 @@ public struct SwiftUISizingContainer<Content: View>: View {
 
 // MARK: - SwiftUISizingContext
 
-/// The context available to the `Content` of a `SwiftUISizingContainer`, used communicate the ideal
-/// size to the container.
+/// The context available to the `Content` of a `SwiftUISizingContainer`, used communicate the
+/// proposed size to the content and the ideal size back to the container.
 public struct SwiftUISizingContext {
 
   // MARK: Lifecycle


### PR DESCRIPTION
## Change summary
We want to additionally support a `UIView` that's intrinsically sized when hosted within a SwiftUI `View`, rather than expanding to fill its parent's offered bounds which is what the current behavior supports.

While we're here, we also rework the way that we compute sizes to no longer require a `DispatchQueue.main.async` by switching to a `ObservableObject` in the sizing context.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
