### PR TITLE
Fix layout ambiguity for LayoutSpacer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.
 - Fixed crash in `ScrollToItemHelper` caused by `preferredFrameRateRanges` on devices running iOS 15.0 (this issue is not present in devices on 15.1+)
+- Fixed an ambiguous layout issue when using `LayoutSpacer` without a `fixedWidth` or `fixedHeight`.
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`

--- a/Sources/EpoxyLayoutGroups/Groups/VGroup.swift
+++ b/Sources/EpoxyLayoutGroups/Groups/VGroup.swift
@@ -12,8 +12,8 @@ public final class VGroup: UILayoutGuide, Constrainable, InternalGroup {
 
   /// Creates a new VGroup
   /// - Parameters:
-  ///   - style: the style for this HGroup that will only be set one time
-  ///   - items: the items that this HGroup will render. These can be set later with setItems()
+  ///   - style: the style for this VGroup that will only be set one time
+  ///   - items: the items that this VGroup will render. These can be set later with setItems()
   public init(
     style: Style = .init(),
     items: [GroupItemModeling] = [])


### PR DESCRIPTION
## Change summary
I noticed that an Airbnb UI component using `VGroup` with a `LayoutSpacer` and `minHeight` had an ambiguous height / vertical position. After looking into the `LayoutSpacer` code, I noticed that it only sets inequality constraints unless a `fixedHeight` is also specified. This change disambiguates the layout by adding an equality constraint when needed. @brynbodayle I know this is something we've discussed in the past even before we have Epoxy Layout Groups - does this seem like the correct solution? I can confirm that it _does_ fix the ambiguous layout for my component.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
