### PR TITLE
Added hosting controller property to EpoxyHostingEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` initializers.
 - Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
   a  SwiftUI `View`.
+- Added `hostingController` property in `EpoxyHostingEnvironment` to access a view's containing `UIViewController`.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -71,6 +71,7 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
 
     super.init(frame: .zero)
 
+    epoxyEnvironment.hostingController = viewController
     epoxyEnvironment.intrinsicContentSizeInvalidator = .init(invalidate: { [weak self] in
       self?.viewController.view.invalidateIntrinsicContentSize()
     })
@@ -352,8 +353,9 @@ final class EpoxyHostingContent<RootView: View>: ObservableObject {
 /// The object that is used to communicate values to SwiftUI views within an
 /// `EpoxySwiftUIHostingController`, e.g. layout margins.
 final class EpoxyHostingEnvironment: ObservableObject {
-  @Published var layoutMargins = EdgeInsets()
+  @Published var hostingController: UIViewController? = nil
   @Published var intrinsicContentSizeInvalidator = EpoxyIntrinsicContentSizeInvalidator(invalidate: {})
+  @Published var layoutMargins = EdgeInsets()
 }
 
 // MARK: - EpoxyHostingWrapper
@@ -366,7 +368,22 @@ struct EpoxyHostingWrapper<Content: View>: View {
 
   var body: some View {
     content.rootView
-      .environment(\.epoxyLayoutMargins, environment.layoutMargins)
+      .environment(\.epoxyHostingController, environment.hostingController)
       .environment(\.epoxyIntrinsicContentSizeInvalidator, environment.intrinsicContentSizeInvalidator)
+      .environment(\.epoxyLayoutMargins, environment.layoutMargins)  }
+}
+
+// MARK: - EnvironmentValues
+
+extension EnvironmentValues {
+  public var epoxyHostingController: UIViewController? {
+    get { self[EpoxyHostingControllerKey.self] }
+    set { self[EpoxyHostingControllerKey.self] = newValue }
   }
+}
+
+// MARK: - EpoxyHostingControllerKey
+
+private struct EpoxyHostingControllerKey: EnvironmentKey {
+  static let defaultValue: UIViewController? = nil
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -370,7 +370,8 @@ struct EpoxyHostingWrapper<Content: View>: View {
     content.rootView
       .environment(\.epoxyHostingController, environment.hostingController)
       .environment(\.epoxyIntrinsicContentSizeInvalidator, environment.intrinsicContentSizeInvalidator)
-      .environment(\.epoxyLayoutMargins, environment.layoutMargins)  }
+      .environment(\.epoxyLayoutMargins, environment.layoutMargins)
+  }
 }
 
 // MARK: - EnvironmentValues


### PR DESCRIPTION
## Change summary
- Added hosting controller property to `EpoxyHostingEnvironment` so a SwiftUI View can access its hosting `UIViewController`. This is necessary for some logging until we move to building an entire screen with SwiftUI components.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
