### PR TITLE
Implement a workaround for the iOS 15 layout recursion crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` initializers.
 - Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
   a  SwiftUI `View`.
+- Added a workaround for an iOS 15 collection view layout recursion crash (disabled by default).
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -444,6 +444,8 @@ open class CollectionView: UICollectionView {
     cell.ephemeralViewCachedStateProvider = { [weak self] state in
       self?.ephemeralStateCache[item.dataID] = state
     }
+
+    cell.resetSelfSizingLayoutRecursionPreventionState()
   }
 
   func configure(

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -13,11 +13,13 @@ public struct CollectionViewConfiguration {
   public init(
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
-    usesAccurateScrollToItem: Bool = true)
+    usesAccurateScrollToItem: Bool = true,
+    enableLayoutRecursionWorkaround: Bool = false)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
+    self.enableLayoutRecursionWorkaround = enableLayoutRecursionWorkaround
   }
 
   // MARK: Public
@@ -66,5 +68,10 @@ public struct CollectionViewConfiguration {
   ///
   /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
+
+  /// `UICollectionView` in iOS 15 will crash if a cell continuously returns an unstable size when self-sizing. Although this is a
+  /// product-code issue, finding the root cause of the ambiguous layouts that cause this crash can be difficult. Setting this to `true`
+  /// will cause self-sizing to short circuit after a few sizing attempts, preventing the layout recursion crash.
+  public var enableLayoutRecursionWorkaround: Bool
 
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -1,6 +1,7 @@
 //  Created by Laura Skelton on 5/19/17.
 //  Copyright © 2017 Airbnb. All rights reserved.
 
+import EpoxyCore
 import UIKit
 
 // MARK: - CollectionViewCell
@@ -124,17 +125,17 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     // layout and we simply return the last computed size for the remainder of the component's life.
     // We reset the count on cell reuse and when the cell is reconfigured in `CollectionView`'s
     // `configure` function.
-    if
-      CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround,
-      let previousComputedSize = previousComputedSize,
-      numberOfNewComputedSizes >= 5
-    {
-      preferredAttributes.size = previousComputedSize
-    }
+    if CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround {
+      if let previousComputedSize = previousComputedSize, numberOfNewComputedSizes >= 5 {
+        EpoxyLogger.shared.assertionFailure(
+          "Layout recursion detected. View: \(view?.description ?? "nil view"). Size: \(preferredAttributes.size).")
+        preferredAttributes.size = previousComputedSize
+      }
 
-    if preferredAttributes.size != previousComputedSize {
-      numberOfNewComputedSizes += 1
-      previousComputedSize = preferredAttributes.size
+      if preferredAttributes.size != previousComputedSize {
+        numberOfNewComputedSizes += 1
+        previousComputedSize = preferredAttributes.size
+      }
     }
 
     return preferredAttributes
@@ -152,6 +153,7 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
   func resetSelfSizingLayoutRecursionPreventionState() {
+    guard CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround else { return }
     numberOfNewComputedSizes = 0
     previousComputedSize = nil
   }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -61,62 +61,89 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     _ layoutAttributes: UICollectionViewLayoutAttributes)
     -> UICollectionViewLayoutAttributes
   {
+    let preferredAttributes: UICollectionViewLayoutAttributes
+
     // There's a downstream `EXC_BAD_ACCESS` crash that would indicate that `layoutAttributes` can
-    // sometimes be `null`, even though it's bridged as `nonnull`. This check guards against this.
-    guard (layoutAttributes as UICollectionViewLayoutAttributes?) != nil else {
-      return super.preferredLayoutAttributesFitting(layoutAttributes)
-    }
-
-    guard let fittingPrioritiesProvider = layoutAttributes as? FittingPrioritiesProvidingLayoutAttributes else {
-      return super.preferredLayoutAttributesFitting(layoutAttributes)
-    }
-
-    let horizontalFittingPriority = fittingPrioritiesProvider.horizontalFittingPriority
-    let verticalFittingPriority = fittingPrioritiesProvider.verticalFittingPriority
-
-    // In some cases, `contentView`'s required width and height constraints
-    // (created from its auto-resizing mask) will not have the correct constants before invoking
-    // `systemLayoutSizeFitting(...)`, causing the cell to size incorrectly. This seems to be a
-    // UIKit bug.
-    // https://openradar.appspot.com/radar?id=5025850143539200
-    // The issue seems most common when the collection view's bounds change (on rotation).
-    // We correct for this by updating `contentView.bounds`, which updates the constants used by the
-    // width and height constraints created by the `contentView`'s auto-resizing mask.
-
+    // sometimes be `null`, even though it's bridged as `nonnull`. This check serves 2 purposes:
+    // - Guarding against the case where `layoutAttributes` is `nil` (which prevents the
+    //   aforementioned crash)
+    // - Determining if we should do some custom sizing logic if our layout attributes instance
+    //   conforms to `FittingPrioritiesProvidingLayoutAttributes`
     if
-      horizontalFittingPriority == .required &&
-      contentView.bounds.width != layoutAttributes.size.width
+      let fittingPrioritiesProvider = layoutAttributes as? FittingPrioritiesProvidingLayoutAttributes
     {
-      contentView.bounds.size.width = layoutAttributes.size.width
-    }
+      let horizontalFittingPriority = fittingPrioritiesProvider.horizontalFittingPriority
+      let verticalFittingPriority = fittingPrioritiesProvider.verticalFittingPriority
 
-    if
-      verticalFittingPriority == .required &&
-      contentView.bounds.height != layoutAttributes.size.height
-    {
-      contentView.bounds.size.height = layoutAttributes.size.height
-    }
+      // In some cases, `contentView`'s required width and height constraints
+      // (created from its auto-resizing mask) will not have the correct constants before invoking
+      // `systemLayoutSizeFitting(...)`, causing the cell to size incorrectly. This seems to be a
+      // UIKit bug.
+      // https://openradar.appspot.com/radar?id=5025850143539200
+      // The issue seems most common when the collection view's bounds change (on rotation).
+      // We correct for this by updating `contentView.bounds`, which updates the constants used by
+      // the width and height constraints created by the `contentView`'s auto-resizing mask.
 
-    let size: CGSize
-    if horizontalFittingPriority != .required || verticalFittingPriority != .required {
-      // Self-sizing is required in at least one dimension.
-      size = super.systemLayoutSizeFitting(
-        layoutAttributes.size,
-        withHorizontalFittingPriority: horizontalFittingPriority,
-        verticalFittingPriority: verticalFittingPriority)
+      if
+        horizontalFittingPriority == .required &&
+        contentView.bounds.width != layoutAttributes.size.width
+      {
+        contentView.bounds.size.width = layoutAttributes.size.width
+      }
+
+      if
+        verticalFittingPriority == .required &&
+        contentView.bounds.height != layoutAttributes.size.height
+      {
+        contentView.bounds.size.height = layoutAttributes.size.height
+      }
+
+      let size: CGSize
+      if horizontalFittingPriority != .required || verticalFittingPriority != .required {
+        // Self-sizing is required in at least one dimension.
+        size = super.systemLayoutSizeFitting(
+          layoutAttributes.size,
+          withHorizontalFittingPriority: horizontalFittingPriority,
+          verticalFittingPriority: verticalFittingPriority)
+      } else {
+        // No self-sizing is required; respect whatever size the layout determined.
+        size = layoutAttributes.size
+      }
+
+      layoutAttributes.size = size
+      preferredAttributes = layoutAttributes
     } else {
-      // No self-sizing is required; respect whatever size the layout determined.
-      size = layoutAttributes.size
+      preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
     }
 
-    layoutAttributes.size = size
+    // On iOS 15, cells that return an unstable size can result in a layout recursion crash. The
+    // root cause of these crashes is likely an ambiguous layout due to misconfigured constraints.
+    // Unfortunately, finding each and every one of these ambiguous layouts can be challenging. This
+    // code works around this new behavior / crash by giving up on self-sizing after 5 attempts.
+    // Once a component has been sized differently 5 times, we assume that it has an ambiguous
+    // layout and we simply return the last computed size for the remainder of the component's life.
+    // We reset the count on cell reuse and when the cell is reconfigured in `CollectionView`'s
+    // `configure` function.
+    if
+      CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround,
+      let previousComputedSize = previousComputedSize,
+      numberOfNewComputedSizes >= 5
+    {
+      preferredAttributes.size = previousComputedSize
+    }
 
-    return layoutAttributes
+    if preferredAttributes.size != previousComputedSize {
+      numberOfNewComputedSizes += 1
+      previousComputedSize = preferredAttributes.size
+    }
+
+    return preferredAttributes
   }
 
   public override func prepareForReuse() {
     super.prepareForReuse()
     ephemeralViewCachedStateProvider?(cachedEphemeralState)
+    resetSelfSizingLayoutRecursionPreventionState()
   }
 
   // MARK: Internal
@@ -124,9 +151,17 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
+  func resetSelfSizingLayoutRecursionPreventionState() {
+    numberOfNewComputedSizes = 0
+    previousComputedSize = nil
+  }
+
   // MARK: Private
 
   private var normalViewBackgroundColor: UIColor?
+
+  private var numberOfNewComputedSizes = 0
+  private var previousComputedSize: CGSize?
 
   private func updateVisualHighlightState(_ isVisuallyHighlighted: Bool) {
     if selectedBackgroundColor == nil { return }


### PR DESCRIPTION
## Change summary
This PR attempts to workaround a layout recursion crash that only happens on iOS 15. Although the root cause of this crash is likely a component with ambiguous Auto Layout constraints, finding the component(s) with this bug can be very difficult (especially considering Xcode can't always detect when a layout is ambiguous).

To work around this crash / product-code bug, I've added some code to make it so that cells stop their sizing attempts after 5 tries. Why 5? Well, some components need 2 passes due to double-layout-pass labels being used. 3 seemed too risky / close to 2. 10 seems like too may attempts. How about half that? Sure, 5 it is 🌝 Open to suggestions 😛 

My plan is to put this change behind a feature flag in Airbnb code.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
