### PR TITLE
[SwiftUI] Improve sizing configurability of SwiftUI-hosted UIViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
   a  SwiftUI `View`.
 - Added a workaround for an iOS 15 collection view layout recursion crash (disabled by default).
+- Added `SwiftUISizingContainerStorage` for hoisting measured ideal size state in view hierarchy to 
+  mitigate jumpiness when a `SwiftUISizingContainer` is hosted within lazy stacks.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -11,16 +11,15 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUISizingContainerConfiguration = .init())
     -> some View
   {
-    SwiftUISizingContainer { context in
+    SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIEpoxyableView<Self>(
         content: content,
         style: style,
         behaviors: behaviors,
-        context: context,
-        sizing: sizing)
+        context: context)
     }
   }
 }
@@ -34,15 +33,14 @@ extension StyledView
   public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUISizingContainerConfiguration = .init())
     -> some View
   {
-    SwiftUISizingContainer { context in
+    SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIStylelessEpoxyableView<Self>(
         content: content,
         behaviors: behaviors,
-        context: context,
-        sizing: sizing)
+        context: context)
     }
   }
 }
@@ -56,15 +54,14 @@ extension StyledView
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUISizingContainerConfiguration = .init())
     -> some View
   {
-    SwiftUISizingContainer { context in
+    SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIContentlessEpoxyableView<Self>(
         style: style,
         behaviors: behaviors,
-        context: context,
-        sizing: sizing)
+        context: context)
     }
   }
 }
@@ -78,14 +75,11 @@ extension StyledView
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerSizing = .intrinsicHeightBoundsWidth)
+    sizing: SwiftUISizingContainerConfiguration = .init())
     -> some View
   {
-    SwiftUISizingContainer { context in
-      SwiftUIStylelessContentlessEpoxyableView<Self>(
-        behaviors: behaviors,
-        context: context,
-        sizing: sizing)
+    SwiftUISizingContainer(configuration: sizing) { context in
+      SwiftUIStylelessContentlessEpoxyableView<Self>(behaviors: behaviors, context: context)
     }
   }
 }
@@ -98,7 +92,6 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -133,11 +126,7 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
     let uiView = View(style: style)
     uiView.setContent(content, animated: false)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(
-      view: self,
-      uiView: uiView,
-      context: context,
-      sizing: sizing)
+    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
 
@@ -151,7 +140,6 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
   var content: View.Content
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
@@ -177,11 +165,7 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
     let uiView = View()
     uiView.setContent(content, animated: false)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(
-      view: self,
-      uiView: uiView,
-      context: context,
-      sizing: sizing)
+    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
 
@@ -195,7 +179,6 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     defer {
@@ -219,11 +202,7 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
   func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View(style: style)
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(
-      view: self,
-      uiView: uiView,
-      context: context,
-      sizing: sizing)
+    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
 
@@ -233,7 +212,6 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
 private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
-  var sizing: SwiftUIMeasurementContainerSizing
 
   func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     wrapper.view = self
@@ -243,10 +221,6 @@ private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UI
   func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View()
     uiView.setBehaviors(behaviors)
-    return SwiftUIMeasurementContainer(
-      view: self,
-      uiView: uiView,
-      context: context,
-      sizing: sizing)
+    return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -121,7 +121,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     case .intrinsicHeightBoundsWidth:
       targetSize = CGSize(
         width: measurementBounds.width,
-        height: UIViewType.layoutFittingCompressedSize.height)
+        height: UIView.layoutFittingCompressedSize.height)
 
       let fittingSize = uiView.systemLayoutSizeFitting(
         targetSize,
@@ -134,7 +134,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
     case .intrinsicWidthBoundsHeight:
       targetSize = CGSize(
-        width: UIViewType.layoutFittingCompressedSize.width,
+        width: UIView.layoutFittingCompressedSize.width,
         height: measurementBounds.height)
 
       let fittingSize = uiView.systemLayoutSizeFitting(
@@ -144,12 +144,10 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
       measuredSize = CGSize(width: fittingSize.width, height: UIView.noIntrinsicMetric)
 
-      context.idealSize = .init(width: measuredSize.width, height: measuredSize.height)
+      context.idealSize = .init(width: measuredSize.width, height: nil)
 
     case .intrinsicSize:
-      targetSize = CGSize(
-        width: UIViewType.layoutFittingCompressedSize.height,
-        height: UIViewType.layoutFittingCompressedSize.height)
+      targetSize = UIView.layoutFittingCompressedSize
 
       measuredSize = uiView.systemLayoutSizeFitting(
         targetSize,

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -16,16 +16,10 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
   // MARK: Lifecycle
 
-  public init(
-    view: SwiftUIView,
-    uiView: UIViewType,
-    context: SwiftUISizingContext,
-    sizing: SwiftUIMeasurementContainerSizing)
-  {
+  public init(view: SwiftUIView, uiView: UIViewType, context: SwiftUISizingContext) {
     self.view = view
     self.uiView = uiView
     self.context = context
-    self.sizing = sizing
     super.init(frame: .zero)
 
     addSubview(uiView)
@@ -61,7 +55,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
   public override func layoutSubviews() {
     super.layoutSubviews()
 
-    switch sizing {
+    switch context.strategy {
     case .intrinsicHeightBoundsWidth, .intrinsicWidthBoundsHeight:
       // We need to re-measure the view whenever the size of the bounds changes and the view is
       // sized to the bounds size, as the previous size will now be incorrect.
@@ -76,8 +70,6 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
   // MARK: Private
 
   private let context: SwiftUISizingContext
-
-  private let sizing: SwiftUIMeasurementContainerSizing
 
   /// The bounds size at the time of the latest measurement.
   ///
@@ -125,7 +117,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     latestMeasurementBoundsSize = measurementBounds
 
     let targetSize, measuredSize: CGSize
-    switch sizing {
+    switch context.strategy {
     case .intrinsicHeightBoundsWidth:
       targetSize = CGSize(
         width: measurementBounds.width,
@@ -138,7 +130,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
       measuredSize = CGSize(width: UIView.noIntrinsicMetric, height: fittingSize.height)
 
-      context.idealSize = (width: nil, height: measuredSize.height)
+      context.idealSize = .init(width: nil, height: measuredSize.height)
 
     case .intrinsicWidthBoundsHeight:
       targetSize = CGSize(
@@ -152,7 +144,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
       measuredSize = CGSize(width: fittingSize.width, height: UIView.noIntrinsicMetric)
 
-      context.idealSize = (width: measuredSize.width, height: measuredSize.height)
+      context.idealSize = .init(width: measuredSize.width, height: measuredSize.height)
 
     case .intrinsicSize:
       targetSize = CGSize(
@@ -164,7 +156,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
         withHorizontalFittingPriority: .fittingSizeLevel,
         verticalFittingPriority: .fittingSizeLevel)
 
-      context.idealSize = (width: measuredSize.width, height: measuredSize.height)
+      context.idealSize = .init(width: measuredSize.width, height: measuredSize.height)
     }
 
     let changed = (latestMeasuredSize != measuredSize)
@@ -176,10 +168,10 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
   }
 }
 
-// MARK: - SwiftUIMeasurementContainerSizing
+// MARK: - SwiftUIMeasurementContainerStrategy
 
-/// The sizing behavior of a `SwiftUIMeasurementContainer`.
-public enum SwiftUIMeasurementContainerSizing {
+/// The measurement strategy of a `SwiftUIMeasurementContainer`.
+public enum SwiftUIMeasurementContainerStrategy {
   /// The `uiView` is sized with its intrinsic height and expands horizontally to fill the bounds
   /// offered by its parent.
   case intrinsicHeightBoundsWidth

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -11,7 +11,7 @@ public struct SwiftUISizingContainerConfiguration {
   // MARK: Lifecycle
 
   public init(
-    estimate: SwiftUIMeasurementContainerContentSize = .defaultEstimatedSize,
+    estimate: SwiftUISizingContainerContentSize = .defaultEstimatedSize,
     strategy: SwiftUIMeasurementContainerStrategy = .intrinsicHeightBoundsWidth,
     storage: SwiftUISizingContainerStorage = .init())
   {
@@ -27,7 +27,7 @@ public struct SwiftUISizingContainerConfiguration {
   ///
   /// Pass `nil` for either `width` or `height` if this container is only used for reading the
   /// proposed size and an ideal size will never be provided.
-  public var estimate: SwiftUIMeasurementContainerContentSize
+  public var estimate: SwiftUISizingContainerContentSize
 
   /// The measurement strategy of a `SwiftUIMeasurementContainer`.
   ///
@@ -88,14 +88,14 @@ public struct SwiftUISizingContainer<Content: View>: View {
   // MARK: Private
 
   private let content: (SwiftUISizingContext) -> Content
-  private let estimate: SwiftUIMeasurementContainerContentSize
+  private let estimate: SwiftUISizingContainerContentSize
   private let strategy: SwiftUIMeasurementContainerStrategy
   @ObservedObject private var storage: SwiftUISizingContainerStorage
 }
 
-// MARK: - SwiftUIMeasurementContainerContentSize
+// MARK: - SwiftUISizingContainerContentSize
 
-public struct SwiftUIMeasurementContainerContentSize {
+public struct SwiftUISizingContainerContentSize {
 
   // MARK: Lifecycle
 
@@ -108,8 +108,14 @@ public struct SwiftUIMeasurementContainerContentSize {
 
   /// The default estimated size used as a placeholder ideal size until `UIView` measurement is able
   /// to occur.
-  public static var defaultEstimatedSize: SwiftUIMeasurementContainerContentSize {
+  public static var defaultEstimatedSize: SwiftUISizingContainerContentSize {
     .init(width: 375, height: 150)
+  }
+
+  /// A nil `height` and `width`, indicating content with no intrinsic height or width, or no
+  /// estimated size.
+  public static var none: SwiftUISizingContainerContentSize {
+    .init(width: nil, height: nil)
   }
 
   /// The width of the content, else `nil` if the content has no intrinsic width.
@@ -135,7 +141,7 @@ public final class SwiftUISizingContainerStorage: ObservableObject {
 
   // MARK: Fileprivate
 
-  @Published fileprivate var ideal = SwiftUIMeasurementContainerContentSize()
+  @Published fileprivate var ideal = SwiftUISizingContainerContentSize()
 }
 
 // MARK: - SwiftUISizingContext
@@ -149,7 +155,7 @@ public struct SwiftUISizingContext {
   public init(
     strategy: SwiftUIMeasurementContainerStrategy,
     proposedSize: CGSize,
-    idealSize: Binding<SwiftUIMeasurementContainerContentSize>)
+    idealSize: Binding<SwiftUISizingContainerContentSize>)
   {
     self.strategy = strategy
     self.proposedSize = proposedSize
@@ -165,5 +171,5 @@ public struct SwiftUISizingContext {
   public var proposedSize: CGSize
 
   /// The ideal or intrinsic size for the content view; updated after its measurement.
-  @Binding public var idealSize: SwiftUIMeasurementContainerContentSize
+  @Binding public var idealSize: SwiftUISizingContainerContentSize
 }

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -62,7 +62,7 @@ public struct SwiftUISizingContainer<Content: View>: View {
   ///   - content: The view content rendered using a `SwiftUISizingContext`, typically returning a
   ///     `SwiftUIMeasurementContainer` wrapping a `UIView`.
   public init(
-    configuration: SwiftUISizingContainerConfiguration,
+    configuration: SwiftUISizingContainerConfiguration = .init(),
     content: @escaping (SwiftUISizingContext) -> Content)
   {
     estimate = configuration.estimate

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -99,7 +99,7 @@ public struct SwiftUIMeasurementContainerContentSize {
 
   // MARK: Lifecycle
 
-  internal init(width: CGFloat? = nil, height: CGFloat? = nil) {
+  public init(width: CGFloat? = nil, height: CGFloat? = nil) {
     self.width = width
     self.height = height
   }


### PR DESCRIPTION
## Change summary
Allow passing in a `SwiftUISizingStorage` `ObservedObject` since there are configurations where `StateObject`s are deallocated when offscreen (e.g. deeply nested views within a `LazyVStack`), and hoisting the sizing storage to the top-level content of the `ForEach` can mitigate this issue.

While we're here we also allow passing through the estimate and the measurement strategy all within a single `SwiftUISizingContainerConfiguration`, rather than specifying them separately.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
