### PR TITLE
[SwiftUI] Gracefully handle intrinsic sizes larger than available space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SwiftUIMeasurementContainer` for calculating the ideal height of a `UIView` for wrapping
   for SwiftUI usage.
 - Added `SwiftUISizingContainer` for handling ideal size and proposed size for a wrapped `UIView`.
-- Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is expected.
-- Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` initializers.
+- Added a method to `CollectionViewReorderingDelegate` to check the reordering destination is 
+  expected.
+- Added the ability to pass a `CollectionViewConfiguration` to the `CollectionViewController` 
+  initializers.
 - Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
   a  SwiftUI `View`.
 - Added a workaround for an iOS 15 collection view layout recursion crash (disabled by default).
@@ -20,8 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.
-- Fixed crash in `ScrollToItemHelper` caused by `preferredFrameRateRanges` on devices running iOS 15.0 (this issue is not present in devices on 15.1+)
+- Fixed crash in `ScrollToItemHelper` caused by `preferredFrameRateRanges` on devices running iOS 
+  15.0 (this issue is not present in devices on 15.1+)
 - Fixed an ambiguous layout issue when using `LayoutSpacer` without a `fixedWidth` or `fixedHeight`.
+- Gracefully support cases where a `SwiftUIMeasurementContainer` with an `intrinsicSize`
+  `SwiftUIMeasurementContainerStrategy` has an intrinsic size that exceeds the proposed size by 
+  compressing rather than overflowing, which could result in broken layouts.
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
@@ -40,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   item in a collection view.
 - Added `itemModel(…)`, `barModel(…)` methods to host a SwiftUI `View` within an Epoxy container and
   the `swiftUIView(…)` method to host an `EpoxyableView` within a SwiftUI `View`
-- Added a SwiftUI environment value for requesting size invalidation of the containing Epoxy collection view cell.
+- Added a SwiftUI environment value for requesting size invalidation of the containing Epoxy 
+  collection view cell.
 
 ### Fixed
 - Fixes an issue that could cause `CollectionView` scroll animation frames to have an incorrect
@@ -68,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed incorrect assertion logging when accessing an item with an invalid index path.
 - Mitigated a `EXC_BAD_ACCESS` crash that caused by a bad `nonnull` bridge in `CollectionViewCell`.
-- Fixed an issue where styles were not being used in the `diffIdentifier` calculation of `GroupItems`.
+- Fixed an issue where styles were not being used in the `diffIdentifier` calculation of 
+  `GroupItems`.
 
 ### Changed
 - The `SectionModel` initializer now requires a `dataID` to make it harder to have sections with
@@ -80,13 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `UpdateStrategy` to `CollectionView` to allow specifying that it should update using non-
   animated `performBatchUpdates(…)`, which can be more performant and behave more predictably than
   `reloadData()`.
-- Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to `HGroup.Style`.
+- Added `reflowsForAccessibilityTypeSizes` and `forceVerticalAccessibilityLayout` properties to 
+  `HGroup.Style`.
 
 ### Fixed
 - Improved `CollectionView` logic for deciding when to `reloadData(…)` over `performBatchUpdates(…)`
   in specific scenarios.
 - Fixed an issue where the `accessibilityAlignment` property of `HGroup` was not being respected.
-- Fixed an issue where `accessibilityAlignment` and `horizontalAlignment` would overwrite one another
+- Fixed an issue where `accessibilityAlignment` and `horizontalAlignment` would overwrite one 
+  another.
 - Break a temporary retain cycle in `.system` presentation style
 
 ### Changed

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -110,8 +110,8 @@ public struct SwiftUISizingContainerContentSize {
   }
 
   public init(_ size: CGSize) {
-    self.width = size.width
-    self.height = size.height
+    width = size.width
+    height = size.height
   }
 
   // MARK: Public

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -109,6 +109,11 @@ public struct SwiftUISizingContainerContentSize {
     self.height = height
   }
 
+  public init(_ size: CGSize) {
+    self.width = size.width
+    self.height = size.height
+  }
+
   // MARK: Public
 
   /// The default estimated size used as a placeholder ideal size until `UIView` measurement is able


### PR DESCRIPTION
## Change summary
Gracefully support cases where a `SwiftUIMeasurementContainer` with an `intrinsicSize` `SwiftUIMeasurementContainerStrategy` has an intrinsic size that exceeds the proposed size by compressing rather than overflowing, which could result in broken layouts.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
