### PR TITLE
Add better layout recursion detection logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
+- Removed the iOS 15 layout recursion workaround, and replaced it with better, side-effect-free logging.
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   initializers.
 - Added additional sizing behaviors to `SwiftUIMeasurementContainer` for sizing `UIView`s hosted in 
   a  SwiftUI `View`.
-- Added a workaround for an iOS 15 collection view layout recursion crash (disabled by default).
 - Added `SwiftUISizingContainerStorage` for hoisting measured ideal size state in view hierarchy to 
   mitigate jumpiness when a `SwiftUISizingContainer` is hosted within lazy stacks.
+- Added an assert and log when we detect an iOS 15 collection view layout recursion crash is about to happen.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.
@@ -32,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
-- Removed the iOS 15 layout recursion workaround, and replaced it with better, side-effect-free logging.
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -445,7 +445,7 @@ open class CollectionView: UICollectionView {
       self?.ephemeralStateCache[item.dataID] = state
     }
 
-    cell.resetSelfSizingLayoutRecursionPreventionState()
+    cell.resetSelfSizingLayoutRecursionTrackingState()
   }
 
   func configure(

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -13,13 +13,11 @@ public struct CollectionViewConfiguration {
   public init(
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
-    usesAccurateScrollToItem: Bool = true,
-    enableLayoutRecursionWorkaround: Bool = false)
+    usesAccurateScrollToItem: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
-    self.enableLayoutRecursionWorkaround = enableLayoutRecursionWorkaround
   }
 
   // MARK: Public
@@ -68,10 +66,5 @@ public struct CollectionViewConfiguration {
   ///
   /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
-
-  /// `UICollectionView` in iOS 15 will crash if a cell continuously returns an unstable size when self-sizing. Although this is a
-  /// product-code issue, finding the root cause of the ambiguous layouts that cause this crash can be difficult. Setting this to `true`
-  /// will cause self-sizing to short circuit after a few sizing attempts, preventing the layout recursion crash.
-  public var enableLayoutRecursionWorkaround: Bool
 
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -120,22 +120,31 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     // On iOS 15, cells that return an unstable size can result in a layout recursion crash. The
     // root cause of these crashes is likely an ambiguous layout due to misconfigured constraints.
     // Unfortunately, finding each and every one of these ambiguous layouts can be challenging. This
-    // code works around this new behavior / crash by giving up on self-sizing after 5 attempts.
-    // Once a component has been sized differently 5 times, we assume that it has an ambiguous
-    // layout and we simply return the last computed size for the remainder of the component's life.
-    // We reset the count on cell reuse and when the cell is reconfigured in `CollectionView`'s
-    // `configure` function.
-    if CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround {
-      if let previousComputedSize = previousComputedSize, numberOfNewComputedSizes >= 5 {
-        EpoxyLogger.shared.assertionFailure(
-          "Layout recursion detected. View: \(view?.description ?? "nil view"). Size: \(preferredAttributes.size).")
-        preferredAttributes.size = previousComputedSize
-      }
+    // code tries to detect these layout issues and logs a warning when one is detected: if a
+    // component size is unstable for at least 50 sizing attempts in less than 2 seconds, we log a
+    // warning.
 
-      if preferredAttributes.size != previousComputedSize {
-        numberOfNewComputedSizes += 1
-        previousComputedSize = preferredAttributes.size
+    let sizingAttemptTime = CACurrentMediaTime()
+    let wasFirstSizingAttemptRecent: Bool
+    if let firstSizingAttemptTime = firstSizingAttemptTime {
+      wasFirstSizingAttemptRecent = sizingAttemptTime - firstSizingAttemptTime < 2
+      if !wasFirstSizingAttemptRecent {
+        // If the last sizing attempt was not nil, but also more than the 2s threshold, reset all
+        // self-sizing-layout-recursion-tracking state.
+        resetSelfSizingLayoutRecursionTrackingState()
       }
+    } else {
+      firstSizingAttemptTime = sizingAttemptTime
+      wasFirstSizingAttemptRecent = false
+    }
+
+    if wasFirstSizingAttemptRecent, previousComputedSizes.count >= 50 {
+      EpoxyLogger.shared.warn(
+        "Layout recursion detected. View: \(view?.description ?? "nil view"). Sizes: \(previousComputedSizes).")
+    }
+
+    if preferredAttributes.size != previousComputedSizes.last {
+      previousComputedSizes.append(preferredAttributes.size)
     }
 
     return preferredAttributes
@@ -144,7 +153,7 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   public override func prepareForReuse() {
     super.prepareForReuse()
     ephemeralViewCachedStateProvider?(cachedEphemeralState)
-    resetSelfSizingLayoutRecursionPreventionState()
+    resetSelfSizingLayoutRecursionTrackingState()
   }
 
   // MARK: Internal
@@ -152,18 +161,17 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
-  func resetSelfSizingLayoutRecursionPreventionState() {
-    guard CollectionViewConfiguration.shared.enableLayoutRecursionWorkaround else { return }
-    numberOfNewComputedSizes = 0
-    previousComputedSize = nil
+  func resetSelfSizingLayoutRecursionTrackingState() {
+    previousComputedSizes.removeAll()
+    firstSizingAttemptTime = nil
   }
 
   // MARK: Private
 
   private var normalViewBackgroundColor: UIColor?
 
-  private var numberOfNewComputedSizes = 0
-  private var previousComputedSize: CGSize?
+  private var previousComputedSizes = [CGSize]()
+  private var firstSizingAttemptTime: TimeInterval?
 
   private func updateVisualHighlightState(_ isVisuallyHighlighted: Bool) {
     if selectedBackgroundColor == nil { return }


### PR DESCRIPTION
## Change summary
This PR adds better layout recursion logging detection. The previous attempt had a few problems:
- Rotation / view width changes could incorrectly trigger the layout recursion detection
- Text input rows that increase in height as text is typed could incorrectly trigger the layout recursion detection

This PR makes a few improvements:
- Rather than try to prevent the crash, this PR simply logs (which should be "safer" / not cause other regressions like the last fix attempt did)
- Increase the sizing-attempt threshold to 50 attempts in less than 2 seconds
- Log the full history of sizing attempts

I tested this in the example project and confirmed the logging works as expected:

```
Layout recursion detected. View: <_TtGC12EpoxyExample13CardContainerC9EpoxyBars12BarStackView_: 0x7f8d8704b8f0; frame = (0 0; 390 232); layer = <CALayer: 0x600000bf0bc0>>. Sizes: [(390.0, 221.0), (390.0, 222.0), (390.0, 223.0), (390.0, 224.0), (390.0, 225.0), (390.0, 226.0), (390.0, 227.0), (390.0, 228.0), (390.0, 229.0), (390.0, 230.0), (390.0, 231.0), (390.0, 232.0), (390.0, 233.0), (390.0, 234.0), (390.0, 235.0), (390.0, 236.0), (390.0, 237.0), (390.0, 238.0), (390.0, 239.0), (390.0, 240.0), (390.0, 241.0), (390.0, 242.0), (390.0, 243.0), (390.0, 244.0), (390.0, 245.0), (390.0, 246.0), (390.0, 247.0), (390.0, 248.0), (390.0, 249.0), (390.0, 250.0), (390.0, 251.0), (390.0, 252.0), (390.0, 253.0), (390.0, 254.0), (390.0, 255.0), (390.0, 256.0), (390.0, 257.0), (390.0, 258.0), (390.0, 259.0), (390.0, 260.0), (390.0, 261.0), (390.0, 262.0), (390.0, 263.0), (390.0, 264.0), (390.0, 265.0), (390.0, 266.0), (390.0, 267.0), (390.0, 268.0), (390.0, 269.0), (390.0, 270.0), (390.0, 271.0), (390.0, 272.0), (390.0, 273.0), (390.0, 274.0), (390.0, 275.0), (390.0, 276.0), (390.0, 277.0), (390.0, 278.0), (390.0, 279.0), (390.0, 280.0), (390.0, 281.0), (390.0, 282.0), (390.0, 283.0), (390.0, 284.0), (390.0, 285.0), (390.0, 286.0), (390.0, 287.0), (390.0, 288.0), (390.0, 289.0), (390.0, 290.0), (390.0, 291.0), (390.0, 292.0), (390.0, 293.0), (390.0, 294.0), (390.0, 295.0), (390.0, 296.0), (390.0, 297.0), (390.0, 298.0), (390.0, 299.0), (390.0, 300.0), (390.0, 301.0), (390.0, 302.0), (390.0, 303.0), (390.0, 304.0), (390.0, 305.0), (390.0, 306.0), (390.0, 307.0), (390.0, 308.0), (390.0, 309.0), (390.0, 310.0), (390.0, 311.0), (390.0, 312.0), (390.0, 313.0), (390.0, 314.0), (390.0, 315.0), (390.0, 316.0), (390.0, 317.0), (390.0, 318.0), (390.0, 319.0), (390.0, 320.0), (390.0, 321.0), (390.0, 322.0), (390.0, 323.0), (390.0, 324.0), (390.0, 325.0), (390.0, 326.0), (390.0, 327.0)].
```

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
