### PR TITLE
Also print parent view controller for layout recursion logging

### DIFF
--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -140,7 +140,7 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
 
     if wasFirstSizingAttemptRecent, previousComputedSizes.count >= 50 {
       EpoxyLogger.shared.assertionFailure(
-        "Layout recursion detected. View: \(view?.invertedHierarchyString ?? "nil view"). Sizes: \(previousComputedSizes).")
+        "Layout recursion detected. View: \(view?.description ?? "nil view"). VC: \(view?.parentViewController?.description ?? "no parent VC"). Sizes: \(previousComputedSizes).")
     }
 
     if preferredAttributes.size != previousComputedSizes.last {
@@ -222,34 +222,18 @@ extension CollectionViewCell {
 
 // MARK: Layout Recursion Debug Helpers
 
-extension UIView {
+extension UIResponder {
 
-  // MARK: Fileprivate
-
-  fileprivate var invertedHierarchyString: String {
-    var viewDescriptions = [description]
-    var next = superview
-    while next != nil {
-      if let desc = next?.description {
-        viewDescriptions.append(desc)
+  fileprivate var parentViewController: UIViewController? {
+    if next is UIViewController {
+      return next as? UIViewController
+    } else {
+      if let next = next {
+        return next.parentViewController
+      } else {
+        return nil
       }
-      next = next?.superview
     }
-    return hierarchyString(from: viewDescriptions.reversed())
-  }
-
-  // MARK: Private
-
-  private func hierarchyString(from viewDescriptions: [String]) -> String {
-    var result = ""
-    for (idx, desc) in viewDescriptions.enumerated() {
-      var prefix = ""
-      if idx > 0 {
-        prefix = String(repeating: " ", count: 4 * idx) + "├─ "
-      }
-      result += "\(prefix)\(desc)\n"
-    }
-    return result
   }
 
 }


### PR DESCRIPTION
## Change summary
Addressing feedback from previous PR https://github.com/airbnb/epoxy-ios/pull/88#discussion_r818333581

This adds VC logging so we have a better idea of which component is the problematic one when we detect layout recursion.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
