### PR TITLE
[SwiftUI] Support bounds size measurement strategy

### DIFF
--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -113,6 +113,13 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
     var measuredSize: CGSize
     switch context.strategy {
+    case .boundsSize:
+      measuredSize = .init(
+        width: UIView.noIntrinsicMetric,
+        height: UIView.noIntrinsicMetric)
+
+      context.idealSize = .init(width: nil, height: nil)
+
     case .intrinsicHeightBoundsWidth:
       let targetSize = CGSize(
         width: measurementBounds.width,
@@ -181,6 +188,8 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
 
 /// The measurement strategy of a `SwiftUIMeasurementContainer`.
 public enum SwiftUIMeasurementContainerStrategy {
+  /// The `uiView` is sized to fill the bounds offered by its parent.
+  case boundsSize
   /// The `uiView` is sized with its intrinsic height and expands horizontally to fill the bounds
   /// offered by its parent.
   case intrinsicHeightBoundsWidth

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -22,6 +22,30 @@ public struct SwiftUISizingContainerConfiguration {
 
   // MARK: Public
 
+  /// The `content` view is sized to fill the bounds offered by its parent.
+  public static var boundsSize: Self {
+    .init(strategy: .boundsSize)
+  }
+
+  /// The `content` view is sized with its intrinsic height and expands horizontally to fill the
+  /// bounds offered by its parent
+  ///
+  /// This is the default configuration.
+  public static var intrinsicHeightBoundsWidth: Self {
+    .init()
+  }
+
+  /// The `content` view is sized with its intrinsic width and expands vertically to fill the bounds
+  /// offered by its parent.
+  public static var intrinsicWidthBoundsHeight: Self {
+    .init(strategy: .intrinsicWidthBoundsHeight)
+  }
+
+  /// The `content` view is sized to its intrinsic width and height.
+  public static var intrinsicSize: Self {
+    .init(strategy: .intrinsicSize)
+  }
+
   /// An estimated size used as a placeholder ideal size until `UIView` measurement is able to
   /// occur.
   ///


### PR DESCRIPTION
## Change summary
Adds a strategy where the `uiView` is sized to fill the bounds offered by its parent, which is useful for UIKit views that we want to expand to fill.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes

This is already covered by another changelog entry