### PR TITLE
[SwiftUI] Add UIView swiftUIView helpers and support additional configuration closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a  SwiftUI `View`.
 - Added `SwiftUISizingContainerStorage` for hoisting measured ideal size state in view hierarchy to 
   mitigate jumpiness when a `SwiftUISizingContainer` is hosted within lazy stacks.
-- Added an assert and log when we detect an iOS 15 collection view layout recursion crash is about to happen.
+- Added an assert and log when we detect an iOS 15 collection view layout recursion crash is about 
+  to happen.
+- Added a static `swiftUIView(…)` method to `UIView` for hosting UIKit views that aren't 
+  `EpoxyableView`s while still leveraging the layout helpers.
+- Added support for calling `configure { _ in }` on the SwiftUI `View` resulting from a 
+  `swiftUIView(…)` invocation to perform additional configuration of the `UIView` instance.
 
 ### Fixed
 - Fixed sizing of reused `EpoxySwiftUIHostingController`s on iOS 15.2+.

--- a/Example/EpoxyExample/ViewControllers/SwiftUI/EpoxyInSwiftUIViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/SwiftUI/EpoxyInSwiftUIViewController.swift
@@ -27,6 +27,9 @@ struct EpoxyInSwiftUIView: View {
           TextRow.swiftUIView(
             content: .init(title: "Row \(index)", body: BeloIpsum.sentence(count: 1, wordCount: index)),
             style: .small)
+            .configure { row in
+              print("Configuring \(row)")
+            }
             .onTapGesture {
               print("Row \(index) tapped!")
             }

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -123,7 +123,7 @@ extension StyledView
 // MARK: - SwiftUIEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with content, behaviors, and style.
-public struct SwiftUIEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+public struct SwiftUIEpoxyableView<View>: UIViewRepresentable, UIViewConfiguringSwiftUIView
   where
   View: EpoxyableView
 {
@@ -177,7 +177,7 @@ public struct SwiftUIEpoxyableView<View>: UIViewRepresentable, SwiftUISizingCont
 // MARK: - SwiftUIStylelessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style`.
-public struct SwiftUIStylelessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+public struct SwiftUIStylelessEpoxyableView<View>: UIViewRepresentable, UIViewConfiguringSwiftUIView
   where
   View: EpoxyableView,
   View.Style == Never
@@ -222,7 +222,7 @@ public struct SwiftUIStylelessEpoxyableView<View>: UIViewRepresentable, SwiftUIS
 // MARK: - SwiftUIContentlessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Content`.
-public struct SwiftUIContentlessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+public struct SwiftUIContentlessEpoxyableView<View>: UIViewRepresentable, UIViewConfiguringSwiftUIView
   where
   View: EpoxyableView,
   View.Content == Never
@@ -265,7 +265,7 @@ public struct SwiftUIContentlessEpoxyableView<View>: UIViewRepresentable, SwiftU
 // MARK: - SwiftUIStylelessContentlessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style` and `Content`.
-public struct SwiftUIStylelessContentlessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+public struct SwiftUIStylelessContentlessEpoxyableView<View>: UIViewRepresentable, UIViewConfiguringSwiftUIView
   where
   View: EpoxyableView,
   View.Content == Never,

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -7,12 +7,21 @@ import SwiftUI
 
 extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurableView {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
+  ///
+  /// To perform additional configuration of the `EpoxyableView` instance, call `configure` on the
+  /// returned SwiftUI `View`:
+  /// ```
+  /// MyView.swiftUIView(…)
+  ///   .configure { (view: MyView) in
+  ///     …
+  ///   }
+  /// ```
   public static func swiftUIView(
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil,
     sizing: SwiftUISizingContainerConfiguration = .init())
-    -> some View
+    -> SwiftUISizingContainer<SwiftUIEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIEpoxyableView<Self>(
@@ -30,11 +39,20 @@ extension StyledView
   Style == Never
 {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
+  ///
+  /// To perform additional configuration of the `EpoxyableView` instance, call `configure` on the
+  /// returned SwiftUI `View`:
+  /// ```
+  /// MyView.swiftUIView(…)
+  ///   .configure { (view: MyView) in
+  ///     …
+  ///   }
+  /// ```
   public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil,
     sizing: SwiftUISizingContainerConfiguration = .init())
-    -> some View
+    -> SwiftUISizingContainer<SwiftUIStylelessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIStylelessEpoxyableView<Self>(
@@ -51,11 +69,20 @@ extension StyledView
   Content == Never
 {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
+  ///
+  /// To perform additional configuration of the `EpoxyableView` instance, call `configure` on the
+  /// returned SwiftUI `View`:
+  /// ```
+  /// MyView.swiftUIView(…)
+  ///   .configure { (view: MyView) in
+  ///     …
+  ///   }
+  /// ```
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil,
     sizing: SwiftUISizingContainerConfiguration = .init())
-    -> some View
+    -> SwiftUISizingContainer<SwiftUIContentlessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIContentlessEpoxyableView<Self>(
@@ -73,10 +100,19 @@ extension StyledView
   Style == Never
 {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
+  ///
+  /// To perform additional configuration of the `EpoxyableView` instance, call `configure` on the
+  /// returned SwiftUI `View`:
+  /// ```
+  /// MyView.swiftUIView(…)
+  ///   .configure { (view: MyView) in
+  ///     …
+  ///   }
+  /// ```
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
     sizing: SwiftUISizingContainerConfiguration = .init())
-    -> some View
+    -> SwiftUISizingContainer<SwiftUIStylelessContentlessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
       SwiftUIStylelessContentlessEpoxyableView<Self>(behaviors: behaviors, context: context)
@@ -86,14 +122,18 @@ extension StyledView
 
 // MARK: - SwiftUIEpoxyableView
 
-/// A SwiftUI `View` representing an `EpoxyableView`.
-private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
+/// A SwiftUI `View` representing an `EpoxyableView` with content, behaviors, and style.
+public struct SwiftUIEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+  where
+  View: EpoxyableView
+{
   var content: View.Content
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  public var configurations: [(View) -> Void] = []
 
-  func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
+  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
 
     defer {
@@ -101,6 +141,10 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
 
       // We always update the view behaviors on every view update.
       wrapper.uiView.setBehaviors(behaviors)
+
+      for configuration in configurations {
+        configuration(wrapper.uiView)
+      }
     }
 
     // We need to create a new view instance when the style is updated.
@@ -122,10 +166,10 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
     // No updates required.
   }
 
-  func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View(style: style)
     uiView.setContent(content, animated: false)
-    uiView.setBehaviors(behaviors)
+    // No need to set behaviors as `updateUIView` is called immediately after construction.
     return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
@@ -133,15 +177,17 @@ private struct SwiftUIEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
 // MARK: - SwiftUIStylelessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style`.
-private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewRepresentable
+public struct SwiftUIStylelessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
   where
+  View: EpoxyableView,
   View.Style == Never
 {
   var content: View.Content
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  public var configurations: [(View) -> Void] = []
 
-  func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
+  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
     let animated = context.transaction.animation != nil
 
     defer {
@@ -149,6 +195,10 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
 
       // We always update the view behaviors on every view update.
       wrapper.uiView.setBehaviors(behaviors)
+
+      for configuration in configurations {
+        configuration(wrapper.uiView)
+      }
     }
 
     // We need to update the content of the existing view when the content is updated.
@@ -161,10 +211,10 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
     // No updates required.
   }
 
-  func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View()
     uiView.setContent(content, animated: false)
-    uiView.setBehaviors(behaviors)
+    // No need to set behaviors as `updateUIView` is called immediately after construction.
     return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
@@ -172,20 +222,26 @@ private struct SwiftUIStylelessEpoxyableView<View: EpoxyableView>: UIViewReprese
 // MARK: - SwiftUIContentlessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Content`.
-private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepresentable
+public struct SwiftUIContentlessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
   where
+  View: EpoxyableView,
   View.Content == Never
 {
   var style: View.Style
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
+  public var configurations: [(View) -> Void] = []
 
-  func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
+  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     defer {
       wrapper.view = self
 
       // We always update the view behaviors on every view update.
       wrapper.uiView.setBehaviors(behaviors)
+
+      for configuration in configurations {
+        configuration(wrapper.uiView)
+      }
     }
 
     // We need to create a new view instance when the style is updated.
@@ -199,9 +255,9 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
     // No updates required.
   }
 
-  func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View(style: style)
-    uiView.setBehaviors(behaviors)
+    // No need to set behaviors as `updateUIView` is called immediately after construction.
     return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }
@@ -209,18 +265,28 @@ private struct SwiftUIContentlessEpoxyableView<View: EpoxyableView>: UIViewRepre
 // MARK: - SwiftUIStylelessContentlessEpoxyableView
 
 /// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style` and `Content`.
-private struct SwiftUIStylelessContentlessEpoxyableView<View: EpoxyableView>: UIViewRepresentable {
+public struct SwiftUIStylelessContentlessEpoxyableView<View>: UIViewRepresentable, SwiftUISizingContainerContent
+  where
+  View: EpoxyableView,
+  View.Content == Never,
+  View.Style == Never
+{
+  public var configurations: [(View) -> Void] = []
   var behaviors: View.Behaviors?
   var context: SwiftUISizingContext
 
-  func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
+  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     wrapper.view = self
     wrapper.uiView.setBehaviors(behaviors)
+
+    for configuration in configurations {
+      configuration(wrapper.uiView)
+    }
   }
 
-  func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     let uiView = View()
-    uiView.setBehaviors(behaviors)
+    // No need to set behaviors as `updateUIView` is called immediately after construction.
     return SwiftUIMeasurementContainer(view: self, uiView: uiView, context: context)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -33,20 +33,12 @@ extension UIViewProtocol {
 /// A `UIViewRepresentable` SwiftUI `View` that wraps its `Content` `UIView` within a
 /// `SwiftUIMeasurementContainer`, expected to be provided a `SwiftUISizingContext` by a parent
 /// `SwiftUISizingContainer`, used to size a UIKit view correctly within a SwiftUI view hierarchy.
-public struct SwiftUIUIView<View: UIView>: UIViewRepresentable, SwiftUISizingContainerContent {
+public struct SwiftUIUIView<View: UIView>: UIViewRepresentable, UIViewConfiguringSwiftUIView {
 
   // MARK: Public
 
   /// An array of closures that are invoked to configure the represented view.
   public var configurations: [(View) -> Void] = []
-
-  /// Returns a copy of this view updated to have the given closure applied to its represented view
-  /// whenever it is updated via the `updateUIView` method.
-  public func configure(_ configure: @escaping (View) -> Void) -> Self {
-    var copy = self
-    copy.configurations.append(configure)
-    return copy
-  }
 
   public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     SwiftUIMeasurementContainer(view: self, uiView: makeView(), context: context)

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -1,0 +1,79 @@
+// Created by eric_horacek on 3/3/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import SwiftUI
+
+// MARK: - UIViewProtocol + swiftUIView
+
+extension UIViewProtocol {
+  /// Returns a SwiftUI `View` representing this `UIView`, constructed with the given `makeView`
+  /// closure and sized with the given sizing configuration.
+  ///
+  /// To perform additional configuration of the `UIView` instance, call `configure` on the
+  /// returned SwiftUI `View`:
+  /// ```
+  /// MyUIView.swiftUIView(…)
+  ///   .configure { (view: MyUIView) in
+  ///     …
+  ///   }
+  /// ```
+  public static func swiftUIView(
+    sizing: SwiftUISizingContainerConfiguration = .init(),
+    makeView: @escaping () -> Self)
+    -> SwiftUISizingContainer<SwiftUIUIView<Self>>
+  {
+    SwiftUISizingContainer(configuration: sizing) { context in
+      SwiftUIUIView(context: context, makeView: makeView)
+    }
+  }
+}
+
+// MARK: - SwiftUIUIView
+
+/// A `UIViewRepresentable` SwiftUI `View` that wraps its `Content` `UIView` within a
+/// `SwiftUIMeasurementContainer`, expected to be provided a `SwiftUISizingContext` by a parent
+/// `SwiftUISizingContainer`, used to size a UIKit view correctly within a SwiftUI view hierarchy.
+public struct SwiftUIUIView<View: UIView>: UIViewRepresentable, SwiftUISizingContainerContent {
+
+  // MARK: Public
+
+  /// An array of closures that are invoked to configure the represented view.
+  public var configurations: [(View) -> Void] = []
+
+  /// Returns a copy of this view updated to have the given closure applied to its represented view
+  /// whenever it is updated via the `updateUIView` method.
+  public func configure(_ configure: @escaping (View) -> Void) -> Self {
+    var copy = self
+    copy.configurations.append(configure)
+    return copy
+  }
+
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
+    SwiftUIMeasurementContainer(view: self, uiView: makeView(), context: context)
+  }
+
+  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
+    wrapper.view = self
+
+    for configuration in configurations {
+      configuration(wrapper.uiView)
+    }
+  }
+
+  // MARK: Internal
+
+  /// The sizing context used to size the represented view.
+  var context: SwiftUISizingContext
+
+  /// A closure that's invoked to construct the represented view.
+  var makeView: () -> View
+}
+
+// MARK: - UIViewProtocol
+
+/// A protocol that all `UIView`s conform to, enabling extensions that have a `Self` reference.
+public protocol UIViewProtocol: UIView {}
+
+// MARK: - UIView + UIViewProtocol
+
+extension UIView: UIViewProtocol {}

--- a/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -1,0 +1,37 @@
+// Created by eric_horacek on 3/4/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import SwiftUI
+
+// MARK: - UIViewConfiguringSwiftUIView
+
+/// A protocol describing a SwiftUI `View` that can configure its `UIView` contents via an array of
+/// `configuration` closures.
+public protocol UIViewConfiguringSwiftUIView: View {
+  /// The `UIView` represented by this view.
+  associatedtype View: UIView
+
+  /// A mutable array of configuration closures that should each be invoked with the represented
+  /// `UIView` whenever `updateUIView` is called in a `UIViewRepresentable`.
+  var configurations: [(View) -> Void] { get set }
+}
+
+// MARK: Extensions
+
+extension UIViewConfiguringSwiftUIView {
+  /// Returns a copy of this view updated to have the given closure applied to its represented view
+  /// whenever it is updated via the `updateUIView` method.
+  public func configure(_ configure: @escaping (View) -> Void) -> Self {
+    var copy = self
+    copy.configurations.append(configure)
+    return copy
+  }
+
+  /// Returns a copy of this view updated to have the given closures applied to its represented view
+  /// whenever it is updated via the `updateUIView` method.
+  public func configurations(_ configurations: [(View) -> Void]) -> Self {
+    var copy = self
+    copy.configurations.append(contentsOf: configurations)
+    return copy
+  }
+}


### PR DESCRIPTION
## Change summary
- Added a static `swiftUIView(…)` method to `UIView` for hosting UIKit views that aren't
  `EpoxyableView`s while still leveraging the layout helpers.
- Added support for calling `configure { _ in }` on the SwiftUI `View` resulting from a
  `swiftUIView(…)` invocation to perform additional configuration of the `UIView` instance.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
