### PR TITLE
[SwiftUI] Don't use estimate sizes in the case of boundsSize or intrinsicSize UIViews

### DIFF
--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -20,7 +20,7 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUISizingContainerConfiguration = .init())
+    sizing: SwiftUISizingContainerConfiguration = .intrinsicHeightBoundsWidth)
     -> SwiftUISizingContainer<SwiftUIEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
@@ -51,7 +51,7 @@ extension StyledView
   public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUISizingContainerConfiguration = .init())
+    sizing: SwiftUISizingContainerConfiguration = .intrinsicHeightBoundsWidth)
     -> SwiftUISizingContainer<SwiftUIStylelessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
@@ -81,7 +81,7 @@ extension StyledView
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil,
-    sizing: SwiftUISizingContainerConfiguration = .init())
+    sizing: SwiftUISizingContainerConfiguration = .intrinsicHeightBoundsWidth)
     -> SwiftUISizingContainer<SwiftUIContentlessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in
@@ -111,7 +111,7 @@ extension StyledView
   /// ```
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
-    sizing: SwiftUISizingContainerConfiguration = .init())
+    sizing: SwiftUISizingContainerConfiguration = .intrinsicHeightBoundsWidth)
     -> SwiftUISizingContainer<SwiftUIStylelessContentlessEpoxyableView<Self>>
   {
     SwiftUISizingContainer(configuration: sizing) { context in

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -114,11 +114,7 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     var measuredSize: CGSize
     switch context.strategy {
     case .boundsSize:
-      measuredSize = .init(
-        width: UIView.noIntrinsicMetric,
-        height: UIView.noIntrinsicMetric)
-
-      context.idealSize = .init(width: nil, height: nil)
+      measuredSize = .init(width: UIView.noIntrinsicMetric, height: UIView.noIntrinsicMetric)
 
     case .intrinsicHeightBoundsWidth:
       let targetSize = CGSize(
@@ -131,7 +127,6 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
         verticalFittingPriority: .fittingSizeLevel)
 
       measuredSize.width = UIView.noIntrinsicMetric
-      context.idealSize = .init(width: nil, height: measuredSize.height)
 
     case .intrinsicWidthBoundsHeight:
       let targetSize = CGSize(
@@ -144,15 +139,12 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
         verticalFittingPriority: .defaultHigh)
 
       measuredSize.height = UIView.noIntrinsicMetric
-      context.idealSize = .init(width: measuredSize.width, height: nil)
 
     case .intrinsicSize:
       measuredSize = uiView.systemLayoutSizeFitting(
         UIView.layoutFittingCompressedSize,
         withHorizontalFittingPriority: .fittingSizeLevel,
         verticalFittingPriority: .fittingSizeLevel)
-
-      var idealSize = SwiftUISizingContainerContentSize(measuredSize)
 
       // If the measured size exceeds the available width or height, set the measured size to
       // `noIntrinsicMetric` to ensure that the component can be compressed, otherwise it will
@@ -162,22 +154,19 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
         latestMeasuredSize == nil || latestMeasuredSize?.width == UIView.noIntrinsicMetric
       {
         measuredSize.width = UIView.noIntrinsicMetric
-        idealSize.width = nil
       }
       if
         measuredSize.height > measurementBounds.height,
         latestMeasuredSize == nil || latestMeasuredSize?.height == UIView.noIntrinsicMetric
       {
         measuredSize.height = UIView.noIntrinsicMetric
-        idealSize.height = nil
       }
-
-      context.idealSize = idealSize
     }
 
     let changed = (latestMeasuredSize != measuredSize)
     if changed {
       latestMeasuredSize = measuredSize
+      context.idealSize = .init(measuredSize)
     }
 
     return (size: measuredSize, changed: changed)

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -102,9 +102,9 @@ public struct SwiftUISizingContainer<Content: View>: View {
 
   public var body: some View {
     if #available(iOS 14, *) {
-      StorageView_iOS14(storage: configuration.storage, content: content(ideal:))
+      StorageView14(storage: configuration.storage, content: content(ideal:))
     } else {
-      StorageView_iOS13(storage: configuration.storage, content: content(ideal:))
+      StorageView13(storage: configuration.storage, content: content(ideal:))
     }
   }
 
@@ -249,11 +249,11 @@ extension SwiftUISizingContainer where Content: UIViewConfiguringSwiftUIView {
   }
 }
 
-// MARK: - StorageView_iOS14
+// MARK: - StorageView14
 
 /// Hosts the `SwiftUISizingContainerStorage` state on iOS 14+ where `StateObject` is available.
 @available(iOS 14, *)
-private struct StorageView_iOS14<Content: View>: View {
+private struct StorageView14<Content: View>: View {
   init(
     storage: SwiftUISizingContainerStorage?,
     content: @escaping (Binding<SwiftUISizingContainerContentSize?>) -> Content)
@@ -270,10 +270,10 @@ private struct StorageView_iOS14<Content: View>: View {
   private var content: (Binding<SwiftUISizingContainerContentSize?>) -> Content
 }
 
-// MARK: - StorageView_iOS13
+// MARK: - StorageView13
 
 /// Hosts the `SwiftUISizingContainerStorage` state on iOS 13 where `StateObject` is not available.
-private struct StorageView_iOS13<Content: View>: View {
+private struct StorageView13<Content: View>: View {
   init(
     storage: SwiftUISizingContainerStorage?,
     content: @escaping (Binding<SwiftUISizingContainerContentSize?>) -> Content)

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUISizingContainer.swift
@@ -11,8 +11,8 @@ public struct SwiftUISizingContainerConfiguration {
   // MARK: Lifecycle
 
   public init(
-    estimate: SwiftUISizingContainerContentSize = .defaultEstimatedSize,
-    strategy: SwiftUIMeasurementContainerStrategy = .intrinsicHeightBoundsWidth,
+    estimate: SwiftUISizingContainerContentSize,
+    strategy: SwiftUIMeasurementContainerStrategy,
     storage: SwiftUISizingContainerStorage = .init())
   {
     self.estimate = estimate
@@ -24,7 +24,9 @@ public struct SwiftUISizingContainerConfiguration {
 
   /// The `content` view is sized to fill the bounds offered by its parent.
   public static var boundsSize: Self {
-    .init(strategy: .boundsSize)
+    // No estimated size is needed in the case of a bounds-sized component it is always sized to fit
+    // the area offered by its parent.
+    .init(estimate: .none, strategy: .boundsSize)
   }
 
   /// The `content` view is sized with its intrinsic height and expands horizontally to fill the
@@ -32,18 +34,20 @@ public struct SwiftUISizingContainerConfiguration {
   ///
   /// This is the default configuration.
   public static var intrinsicHeightBoundsWidth: Self {
-    .init()
+    .init(estimate: .defaultEstimatedSize, strategy: .intrinsicHeightBoundsWidth)
   }
 
   /// The `content` view is sized with its intrinsic width and expands vertically to fill the bounds
   /// offered by its parent.
   public static var intrinsicWidthBoundsHeight: Self {
-    .init(strategy: .intrinsicWidthBoundsHeight)
+    .init(estimate: .defaultEstimatedSize, strategy: .intrinsicWidthBoundsHeight)
   }
 
   /// The `content` view is sized to its intrinsic width and height.
   public static var intrinsicSize: Self {
-    .init(strategy: .intrinsicSize)
+    // No estimated size is needed in the case of intrinsically sized components since they don't
+    // require a two-phase layout with an estimated size.
+    .init(estimate: .none, strategy: .intrinsicSize)
   }
 
   /// An estimated size used as a placeholder ideal size until `UIView` measurement is able to
@@ -86,7 +90,7 @@ public struct SwiftUISizingContainer<Content: View>: View {
   ///   - content: The view content rendered using a `SwiftUISizingContext`, typically returning a
   ///     `SwiftUIMeasurementContainer` wrapping a `UIView`.
   public init(
-    configuration: SwiftUISizingContainerConfiguration = .init(),
+    configuration: SwiftUISizingContainerConfiguration,
     content: @escaping (SwiftUISizingContext) -> Content)
   {
     estimate = configuration.estimate

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -18,7 +18,7 @@ extension UIViewProtocol {
   ///   }
   /// ```
   public static func swiftUIView(
-    sizing: SwiftUISizingContainerConfiguration = .init(),
+    sizing: SwiftUISizingContainerConfiguration = .intrinsicHeightBoundsWidth,
     makeView: @escaping () -> Self)
     -> SwiftUISizingContainer<SwiftUIUIView<Self>>
   {


### PR DESCRIPTION
## Change summary
In both of these cases, we don't need an estimate.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
