### PR TITLE
[SwiftUI] Only handle intrinsic size overflow after the first layout pass

### DIFF
--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -152,20 +152,24 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
         withHorizontalFittingPriority: .fittingSizeLevel,
         verticalFittingPriority: .fittingSizeLevel)
 
-      // If the measured size exceeds the available width or height, set the measured size to
-      // `noIntrinsicMetric` to ensure that the component can be compressed, otherwise it will
-      // overflow beyond the proposed size.
-      if
-        measuredSize.width > bounds.width,
-        latestMeasuredSize == nil || latestMeasuredSize?.width == UIView.noIntrinsicMetric
-      {
-        measuredSize.width = UIView.noIntrinsicMetric
-      }
-      if
-        measuredSize.height > bounds.height,
-        latestMeasuredSize == nil || latestMeasuredSize?.height == UIView.noIntrinsicMetric
-      {
-        measuredSize.height = UIView.noIntrinsicMetric
+      // Once we've set the ideal size after the first measurement pass where we communicate the
+      // ideal size up to the enclosing `SwiftUISizingContainer`:
+      if context.idealSize != nil {
+        // If the measured size exceeds the available width or height, set the measured size to
+        // `noIntrinsicMetric` to ensure that the component can be compressed, otherwise it will
+        // overflow beyond the proposed size.
+        if
+          measuredSize.width > bounds.width,
+          latestMeasuredSize == nil || latestMeasuredSize?.width == UIView.noIntrinsicMetric
+        {
+          measuredSize.width = UIView.noIntrinsicMetric
+        }
+        if
+          measuredSize.height > bounds.height,
+          latestMeasuredSize == nil || latestMeasuredSize?.height == UIView.noIntrinsicMetric
+        {
+          measuredSize.height = UIView.noIntrinsicMetric
+        }
       }
     }
 


### PR DESCRIPTION
## Change summary
This ensures that we don't end up with a compressed component that exceeded the available width/height only on the first layout pass when it wasn't yet valid.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes (this is handled by the changelog entry from #87)
