### PR TITLE
Update HGroupView and VGroupView to have insetsLayoutMarginsFromSafeArea = false by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
+- Updated `HGroupView` and `VGroupView` to have `insetsLayoutMarginsFromSafeArea = false` by default
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/Sources/EpoxyLayoutGroups/Views/HGroupView.swift
+++ b/Sources/EpoxyLayoutGroups/Views/HGroupView.swift
@@ -17,6 +17,7 @@ public final class HGroupView: UIView, EpoxyableView {
     hGroup = HGroup(style: style.hGroupStyle)
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
+    insetsLayoutMarginsFromSafeArea = false
     updateLayoutMargins()
     hGroup.install(in: self)
 

--- a/Sources/EpoxyLayoutGroups/Views/VGroupView.swift
+++ b/Sources/EpoxyLayoutGroups/Views/VGroupView.swift
@@ -17,6 +17,7 @@ public final class VGroupView: UIView, EpoxyableView {
     vGroup = VGroup(style: style.vGroupStyle)
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
+    insetsLayoutMarginsFromSafeArea = false
     updateLayoutMargins()
     vGroup.install(in: self)
 


### PR DESCRIPTION
## Change summary
Update HGroupView and VGroupView to have insetsLayoutMarginsFromSafeArea = false by default

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
