### PR TITLE
Add support for generating docc docuemntation on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,11 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets:
+      - EpoxyCore
+      - EpoxyCollectionView
+      - EpoxyBars
+      - EpoxyNavigationController
+      - EpoxyPresentations
+      - EpoxyLayoutGroups

--- a/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,6 +36,15 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
+      },
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,6 +36,15 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
+      },
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -39,3 +39,10 @@ let package = Package(
     .testTarget(name: "EpoxyTests", dependencies: ["Epoxy", "Quick", "Nimble"]),
     .testTarget(name: "PerformanceTests", dependencies: ["EpoxyCore"]),
   ])
+
+#if swift(>=5.6)
+// Add the documentation compiler plugin if possible
+package.dependencies.append(
+  .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+)
+#endif


### PR DESCRIPTION
## Change summary
Following the steps here https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ensure CI is successful
- [x] view generated docs locally

## Pull request checklist
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
