### PR TITLE
Remove and gate old workarounds by iOS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a  SwiftUI `View`.
 - Added `SwiftUISizingContainerStorage` for hoisting measured ideal size state in view hierarchy to 
   mitigate jumpiness when a `SwiftUISizingContainer` is hosted within lazy stacks.
-- Added an assert and log when we detect an iOS 15 collection view layout recursion crash is about 
-  to happen.
 - Added a static `swiftUIView(…)` method to `UIView` for hosting UIKit views that aren't 
   `EpoxyableView`s while still leveraging the layout helpers.
 - Added support for calling `configure { _ in }` on the SwiftUI `View` resulting from a 
@@ -40,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
 - Updated `HGroupView` and `VGroupView` to have `insetsLayoutMarginsFromSafeArea = false` by default
+- Gated an old autoresizing-mask-related bug workaround to only run on iOS versions 13 and below
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -444,8 +444,6 @@ open class CollectionView: UICollectionView {
     cell.ephemeralViewCachedStateProvider = { [weak self] state in
       self?.ephemeralStateCache[item.dataID] = state
     }
-
-    cell.resetSelfSizingLayoutRecursionTrackingState()
   }
 
   func configure(

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -74,7 +74,9 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
       let horizontalFittingPriority = fittingPrioritiesProvider.horizontalFittingPriority
       let verticalFittingPriority = fittingPrioritiesProvider.verticalFittingPriority
 
-      if #unavailable(iOS 14.0) {
+      if #available(iOS 14, *) {
+        // Issue is fixed in iOS 14+.
+      } else {
         // In some cases, `contentView`'s required width and height constraints
         // (created from its auto-resizing mask) will not have the correct constants before invoking
         // `systemLayoutSizeFitting(...)`, causing the cell to size incorrectly. This seems to be a
@@ -83,7 +85,6 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
         // The issue seems most common when the collection view's bounds change (on rotation).
         // We correct for this by updating `contentView.bounds`, which updates the constants used by
         // the width and height constraints created by the `contentView`'s auto-resizing mask.
-        // Issue is fixed in iOS 14+.
         if
           horizontalFittingPriority == .required &&
           contentView.bounds.width != layoutAttributes.size.width

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -62,8 +62,6 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     _ layoutAttributes: UICollectionViewLayoutAttributes)
     -> UICollectionViewLayoutAttributes
   {
-    let preferredAttributes: UICollectionViewLayoutAttributes
-
     // There's a downstream `EXC_BAD_ACCESS` crash that would indicate that `layoutAttributes` can
     // sometimes be `null`, even though it's bridged as `nonnull`. This check serves 2 purposes:
     // - Guarding against the case where `layoutAttributes` is `nil` (which prevents the
@@ -76,27 +74,29 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
       let horizontalFittingPriority = fittingPrioritiesProvider.horizontalFittingPriority
       let verticalFittingPriority = fittingPrioritiesProvider.verticalFittingPriority
 
-      // In some cases, `contentView`'s required width and height constraints
-      // (created from its auto-resizing mask) will not have the correct constants before invoking
-      // `systemLayoutSizeFitting(...)`, causing the cell to size incorrectly. This seems to be a
-      // UIKit bug.
-      // https://openradar.appspot.com/radar?id=5025850143539200
-      // The issue seems most common when the collection view's bounds change (on rotation).
-      // We correct for this by updating `contentView.bounds`, which updates the constants used by
-      // the width and height constraints created by the `contentView`'s auto-resizing mask.
+      if #unavailable(iOS 14.0) {
+        // In some cases, `contentView`'s required width and height constraints
+        // (created from its auto-resizing mask) will not have the correct constants before invoking
+        // `systemLayoutSizeFitting(...)`, causing the cell to size incorrectly. This seems to be a
+        // UIKit bug.
+        // https://openradar.appspot.com/radar?id=5025850143539200
+        // The issue seems most common when the collection view's bounds change (on rotation).
+        // We correct for this by updating `contentView.bounds`, which updates the constants used by
+        // the width and height constraints created by the `contentView`'s auto-resizing mask.
+        // Issue is fixed in iOS 14+.
+        if
+          horizontalFittingPriority == .required &&
+          contentView.bounds.width != layoutAttributes.size.width
+        {
+          contentView.bounds.size.width = layoutAttributes.size.width
+        }
 
-      if
-        horizontalFittingPriority == .required &&
-        contentView.bounds.width != layoutAttributes.size.width
-      {
-        contentView.bounds.size.width = layoutAttributes.size.width
-      }
-
-      if
-        verticalFittingPriority == .required &&
-        contentView.bounds.height != layoutAttributes.size.height
-      {
-        contentView.bounds.size.height = layoutAttributes.size.height
+        if
+          verticalFittingPriority == .required &&
+          contentView.bounds.height != layoutAttributes.size.height
+        {
+          contentView.bounds.size.height = layoutAttributes.size.height
+        }
       }
 
       let size: CGSize
@@ -112,48 +112,15 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
       }
 
       layoutAttributes.size = size
-      preferredAttributes = layoutAttributes
+      return layoutAttributes
     } else {
-      preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+      return super.preferredLayoutAttributesFitting(layoutAttributes)
     }
-
-    // On iOS 15, cells that return an unstable size can result in a layout recursion crash. The
-    // root cause of these crashes is likely an ambiguous layout due to misconfigured constraints.
-    // Unfortunately, finding each and every one of these ambiguous layouts can be challenging. This
-    // code tries to detect these layout issues and logs a warning when one is detected: if a
-    // component size is unstable for at least 10 sizing attempts in less than 0.1s, we assert since
-    // collection view is about to crash anyways.
-
-    let sizingAttemptTime = CACurrentMediaTime()
-    let wasFirstSizingAttemptRecent: Bool
-    if let firstSizingAttemptTime = firstSizingAttemptTime {
-      wasFirstSizingAttemptRecent = sizingAttemptTime - firstSizingAttemptTime < 0.1
-      if !wasFirstSizingAttemptRecent {
-        // If the last sizing attempt was not nil, but also more than the 2s threshold, reset all
-        // self-sizing-layout-recursion-tracking state.
-        resetSelfSizingLayoutRecursionTrackingState()
-      }
-    } else {
-      firstSizingAttemptTime = sizingAttemptTime
-      wasFirstSizingAttemptRecent = false
-    }
-
-    if wasFirstSizingAttemptRecent, previousComputedSizes.count >= 10 {
-      EpoxyLogger.shared.assertionFailure(
-        "Layout recursion detected. View: \(view?.description ?? "nil view"). VC: \(view?.parentViewController?.description ?? "no parent VC"). Sizes: \(previousComputedSizes).")
-    }
-
-    if preferredAttributes.size != previousComputedSizes.last {
-      previousComputedSizes.append(preferredAttributes.size)
-    }
-
-    return preferredAttributes
   }
 
   public override func prepareForReuse() {
     super.prepareForReuse()
     ephemeralViewCachedStateProvider?(cachedEphemeralState)
-    resetSelfSizingLayoutRecursionTrackingState()
   }
 
   // MARK: Internal
@@ -161,17 +128,9 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
-  func resetSelfSizingLayoutRecursionTrackingState() {
-    previousComputedSizes.removeAll()
-    firstSizingAttemptTime = nil
-  }
-
   // MARK: Private
 
   private var normalViewBackgroundColor: UIColor?
-
-  private var previousComputedSizes = [CGSize]()
-  private var firstSizingAttemptTime: CFTimeInterval?
 
   private func updateVisualHighlightState(_ isVisuallyHighlighted: Bool) {
     if selectedBackgroundColor == nil { return }
@@ -218,22 +177,4 @@ extension CollectionViewCell {
     super.accessibilityElementDidLoseFocus()
     accessibilityDelegate?.collectionViewCellDidLoseFocus(cell: self)
   }
-}
-
-// MARK: Layout Recursion Debug Helpers
-
-extension UIResponder {
-
-  fileprivate var parentViewController: UIViewController? {
-    if next is UIViewController {
-      return next as? UIViewController
-    } else {
-      if let next = next {
-        return next.parentViewController
-      } else {
-        return nil
-      }
-    }
-  }
-
 }


### PR DESCRIPTION
## Change summary
I went through some old radars that I filed to see if any had been fixed - this one has been for iOS 14+.

I also removed the layout recursion detection since we have a better method (this one never really worked properly).

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
