### PR TITLE
Fix redundant constraints identified Xcode 14

### DIFF
--- a/Sources/EpoxyBars/BarModel/EpoxyableView+BarModel.swift
+++ b/Sources/EpoxyBars/BarModel/EpoxyableView+BarModel.swift
@@ -5,7 +5,7 @@ import EpoxyCore
 
 // MARK: - StyledView
 
-extension StyledView where Self: EpoxyableView {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView {
   /// Constructs a `BarModel` with an instance of this view as its bar view.
   ///
   /// - Parameters:
@@ -40,7 +40,7 @@ extension StyledView where Self: EpoxyableView {
 
 // MARK: Style == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Style == Never {
   /// Constructs a `BarModel` with an instance of this view as its bar view.
   ///
   /// - Parameters:
@@ -71,7 +71,7 @@ extension StyledView where Self: EpoxyableView, Style == Never {
 
 // MARK: Content == Never
 
-extension StyledView where Self: EpoxyableView, Content == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Content == Never {
   /// Constructs a `BarModel` with an instance of this view as its bar view.
   ///
   /// - Parameters:
@@ -98,7 +98,12 @@ extension StyledView where Self: EpoxyableView, Content == Never {
 
 // MARK: Style == Never, Content == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never, Content == Never {
+extension StyledView
+  where
+  Self: BehaviorsConfigurableView & ContentConfigurableView,
+  Style == Never,
+  Content == Never
+{
   /// Constructs a `BarModel` with an instance of this view as its bar view.
   ///
   /// - Parameters:

--- a/Sources/EpoxyCollectionView/Models/ItemModel/EpoxyableView+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/EpoxyableView+ItemModel.swift
@@ -5,7 +5,7 @@ import EpoxyCore
 
 // MARK: - StyledView
 
-extension StyledView where Self: EpoxyableView {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView {
   /// Constructs an `ItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -40,7 +40,7 @@ extension StyledView where Self: EpoxyableView {
 
 // MARK: Style == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Style == Never {
   /// Constructs an `ItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -71,7 +71,7 @@ extension StyledView where Self: EpoxyableView, Style == Never {
 
 // MARK: Content == Never
 
-extension StyledView where Self: EpoxyableView, Content == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Content == Never {
   /// Constructs an `ItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -98,7 +98,12 @@ extension StyledView where Self: EpoxyableView, Content == Never {
 
 // MARK: Style == Never, Content == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never, Content == Never {
+extension StyledView
+  where
+  Self: BehaviorsConfigurableView & ContentConfigurableView,
+  Style == Never,
+  Content == Never
+{
   /// Constructs an `ItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/EpoxyableView+SupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/EpoxyableView+SupplementaryItemModel.swift
@@ -5,7 +5,7 @@ import EpoxyCore
 
 // MARK: - StyledView
 
-extension StyledView where Self: EpoxyableView {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView {
   /// Constructs a `SupplementaryItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -40,7 +40,7 @@ extension StyledView where Self: EpoxyableView {
 
 // MARK: Style == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Style == Never {
   /// Constructs a `SupplementaryItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -71,7 +71,7 @@ extension StyledView where Self: EpoxyableView, Style == Never {
 
 // MARK: Content == Never
 
-extension StyledView where Self: EpoxyableView, Content == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Content == Never {
   /// Constructs a `SupplementaryItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:
@@ -98,7 +98,12 @@ extension StyledView where Self: EpoxyableView, Content == Never {
 
 // MARK: Style == Never, Content == Never
 
-extension StyledView where Self: EpoxyableView, Style == Never, Content == Never {
+extension StyledView
+  where
+  Self: BehaviorsConfigurableView & ContentConfigurableView,
+  Style == Never,
+  Content == Never
+{
   /// Constructs a `SupplementaryItemModel` with an instance of this view as its item view.
   ///
   /// - Parameters:

--- a/Sources/EpoxyLayoutGroups/Extensions/EpoxyableView+GroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Extensions/EpoxyableView+GroupItem.swift
@@ -4,7 +4,7 @@
 import EpoxyCore
 import UIKit
 
-extension StyledView where Self: EpoxyableView {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView {
   /// Produces an item to be used within a Group
   /// - Parameters:
   ///   - dataID: the unique identifier for this item
@@ -33,7 +33,7 @@ extension StyledView where Self: EpoxyableView {
   }
 }
 
-extension StyledView where Self: EpoxyableView, Style == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Style == Never {
   /// Produces an item to be used within a Group
   /// - Parameters:
   ///   - dataID: the unique identifier for this item
@@ -59,7 +59,7 @@ extension StyledView where Self: EpoxyableView, Style == Never {
   }
 }
 
-extension StyledView where Self: EpoxyableView, Content == Never {
+extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurableView, Content == Never {
   /// Produces an item to be used within a Group
   /// - Parameters:
   ///   - dataID: the unique identifier for this item
@@ -81,7 +81,12 @@ extension StyledView where Self: EpoxyableView, Content == Never {
   }
 }
 
-extension StyledView where Self: EpoxyableView, Content == Never, Style == Never {
+extension StyledView
+  where
+  Self: BehaviorsConfigurableView & ContentConfigurableView,
+  Content == Never,
+  Style == Never
+{
   /// Produces an item to be used within a Group
   /// - Parameters:
   ///   - dataID: the unique identifier for this item


### PR DESCRIPTION
## Change summary
We can't write `StyledView where Self: EpoxyableView` since that implies two `StyledView` conformances as `EpoxyableView` is defined as:
```swift 
typealias EpoxyableView = StyledView & ContentConfigurableView & BehaviorsConfigurableView
```

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ensure CI is sucessful

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
