### PR TITLE
[SwiftUI] Fix size invalidation in a UICollectionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gracefully support cases where a `SwiftUIMeasurementContainer` with an `intrinsicSize`
   `SwiftUIMeasurementContainerStrategy` has an intrinsic size that exceeds the proposed size by
   compressing rather than overflowing, which could result in broken layouts.
+- Fixed intrinsic size invalidation triggered by a SwiftUI view from within a collection view 
+  cell by invalidating the enclosing collection view layout.
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`

--- a/Example/EpoxyExample.xcodeproj/project.pbxproj
+++ b/Example/EpoxyExample.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		A67255722718C8E40085346B /* UIViewController+LayoutGroupsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67255712718C8E40085346B /* UIViewController+LayoutGroupsExample.swift */; };
 		A67255782718DAFA0085346B /* UIViewController+ReadmeExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67255772718DAFA0085346B /* UIViewController+ReadmeExample.swift */; };
 		A6990DCC25633D8600689965 /* Epoxy in Frameworks */ = {isa = PBXBuildFile; productRef = A6990DCB25633D8600689965 /* Epoxy */; };
+		A6BABA752874B6E6004C49E3 /* SwiftUIInEpoxyResizingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BABA742874B6E6004C49E3 /* SwiftUIInEpoxyResizingViewController.swift */; };
 		A6F0928B25B9E983007D902B /* TextRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F0928A25B9E983007D902B /* TextRow.swift */; };
 		A6F0928F25B9ECC6007D902B /* ReadmeExamplesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F0928E25B9ECC6007D902B /* ReadmeExamplesViewController.swift */; };
 		A6F0929325B9ED0C007D902B /* CounterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F0929225B9ED0C007D902B /* CounterViewController.swift */; };
@@ -123,6 +124,7 @@
 		A672556A271788210085346B /* CompositionalLayoutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompositionalLayoutViewController.swift; sourceTree = "<group>"; };
 		A67255712718C8E40085346B /* UIViewController+LayoutGroupsExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+LayoutGroupsExample.swift"; sourceTree = "<group>"; };
 		A67255772718DAFA0085346B /* UIViewController+ReadmeExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ReadmeExample.swift"; sourceTree = "<group>"; };
+		A6BABA742874B6E6004C49E3 /* SwiftUIInEpoxyResizingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIInEpoxyResizingViewController.swift; sourceTree = "<group>"; };
 		A6F0928A25B9E983007D902B /* TextRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextRow.swift; sourceTree = "<group>"; };
 		A6F0928E25B9ECC6007D902B /* ReadmeExamplesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadmeExamplesViewController.swift; sourceTree = "<group>"; };
 		A6F0929225B9ED0C007D902B /* CounterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewController.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 			children = (
 				A67255602717874A0085346B /* EpoxyInSwiftUIViewController.swift */,
 				A67255612717874A0085346B /* SwiftUIInEpoxyViewController.swift */,
+				A6BABA742874B6E6004C49E3 /* SwiftUIInEpoxyResizingViewController.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				25D39B3926277F0D00B3DBF9 /* MessagesViewController.swift in Sources */,
 				A672556B271788210085346B /* FlowLayoutViewController.swift in Sources */,
 				25D39B5C262789E000B3DBF9 /* AlignableTextRow.swift in Sources */,
+				A6BABA752874B6E6004C49E3 /* SwiftUIInEpoxyResizingViewController.swift in Sources */,
 				25D39B3626277F0D00B3DBF9 /* ColorsViewController.swift in Sources */,
 				25B6765F25AE883700C00B20 /* ProductViewController.swift in Sources */,
 				A61AFF632602BA2B005356A8 /* NavigationWrapperViewController.swift in Sources */,

--- a/Example/EpoxyExample/Data/Example.swift
+++ b/Example/EpoxyExample/Data/Example.swift
@@ -14,6 +14,7 @@ enum Example: CaseIterable {
   case layoutGroups
   case swiftUIToEpoxy
   case epoxyToSwiftUI
+  case swiftUIToEpoxyResizing
 
   // MARK: Internal
 
@@ -41,6 +42,8 @@ enum Example: CaseIterable {
       return "SwiftUI in Epoxy"
     case .epoxyToSwiftUI:
       return "Epoxy in SwiftUI"
+    case .swiftUIToEpoxyResizing:
+      return "SwiftUI in Epoxy, Resizing Cells"
     }
   }
 
@@ -68,6 +71,8 @@ enum Example: CaseIterable {
       return "An example of SwiftUI views being embedded in Epoxy"
     case .epoxyToSwiftUI:
       return "An example of Epoxy views being embedded in SwiftUI"
+    case .swiftUIToEpoxyResizing:
+      return "An example of SwiftUI views being embedded in Epoxy that can invalidate their size"
     }
   }
 }

--- a/Example/EpoxyExample/ViewControllers/MainViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/MainViewController.swift
@@ -120,6 +120,8 @@ final class MainViewController: NavigationController {
       return SwiftUIInEpoxyViewController()
     case .epoxyToSwiftUI:
       return EpoxyInSwiftUIViewController()
+    case .swiftUIToEpoxyResizing:
+      return SwiftUIInEpoxyResizingViewController()
     }
     viewController.title = example.title
     return viewController

--- a/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
@@ -5,7 +5,7 @@ import Epoxy
 import SwiftUI
 import UIKit
 
-// MARK: - SwiftUIInEpoxyViewController
+// MARK: - SwiftUIInEpoxyResizingViewController
 
 /// An example view controller that renders an scrollable list of SwiftUI text rows in an Epoxy
 /// container that can expand on tap.
@@ -29,7 +29,7 @@ final class SwiftUIInEpoxyResizingViewController: CollectionViewController {
   }
 }
 
-// MARK: - SwiftUITextRow
+// MARK: - SwiftUIExpandableRow
 
 /// An implementation of `TextRow` in SwiftUI.
 struct SwiftUIExpandableRow: View {

--- a/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
@@ -31,7 +31,7 @@ final class SwiftUIInEpoxyResizingViewController: CollectionViewController {
 
 // MARK: - SwiftUIExpandableRow
 
-/// An implementation of `TextRow` in SwiftUI.
+/// An implementation of an expandable row in SwiftUI, which has a local isExpanded state.
 struct SwiftUIExpandableRow: View {
   var title: String
   var subtitle: String

--- a/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/SwiftUI/SwiftUIInEpoxyResizingViewController.swift
@@ -1,0 +1,65 @@
+// Created by eric_horacek on 7/5/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import Epoxy
+import SwiftUI
+import UIKit
+
+// MARK: - SwiftUIInEpoxyViewController
+
+/// An example view controller that renders an scrollable list of SwiftUI text rows in an Epoxy
+/// container that can expand on tap.
+final class SwiftUIInEpoxyResizingViewController: CollectionViewController {
+
+  // MARK: Lifecycle
+
+  init() {
+    super.init(layout: UICollectionViewCompositionalLayout.listNoDividers)
+    setItems(items, animated: false)
+  }
+
+  // MARK: Private
+
+  private var items: [ItemModeling] {
+    (1...100).map { (index: Int) in
+      SwiftUIExpandableRow(title: "Row \(index)", subtitle: BeloIpsum.sentence(count: 1, wordCount: index))
+        // Since each view has its own state, it needs its own reuse ID.
+        .itemModel(dataID: index, reuseBehavior: .unique(reuseID: index))
+    }
+  }
+}
+
+// MARK: - SwiftUITextRow
+
+/// An implementation of `TextRow` in SwiftUI.
+struct SwiftUIExpandableRow: View {
+  var title: String
+  var subtitle: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(title)
+        .font(Font.body)
+        .foregroundColor(Color(.label))
+      if isExpanded {
+        Text(subtitle)
+          .font(Font.caption)
+          .foregroundColor(Color(.secondaryLabel))
+          .transition(.opacity.combined(with: .move(edge: .top)))
+      }
+    }
+    .animation(.default, value: isExpanded)
+    .padding(EdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24))
+    // Ensure that the text is aligned to the leading edge of the container when it expands beyond
+    // its ideal width, instead of the center (the default).
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      isExpanded.toggle()
+      invalidateIntrinsicContentSize()
+    }
+  }
+
+  @State private var isExpanded = false
+  @Environment(\.epoxyIntrinsicContentSizeInvalidator) var invalidateIntrinsicContentSize
+}

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -73,6 +73,16 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
 
     epoxyEnvironment.intrinsicContentSizeInvalidator = .init(invalidate: { [weak self] in
       self?.viewController.view.invalidateIntrinsicContentSize()
+
+      // Inform the enclosing collection view that the size has changed, if we're contained in one,
+      // allowing the cell to resize.
+      //
+      // On iOS 16+, we could call `invalidateIntrinsicContentSize()` on the enclosing collection
+      // view cell instead, but that currently causes visual artifacts with `MagazineLayout`. The
+      // better long term fix is likely to switch to `UIHostingConfiguration` on iOS 16+ anyways.
+      if let enclosingCollectionView = self?.superview?.superview?.superview as? UICollectionView {
+        enclosingCollectionView.collectionViewLayout.invalidateLayout()
+      }
     })
     layoutMargins = .zero
   }


### PR DESCRIPTION
## Change summary
We need to invalidate the layout to get the the enclosing UICollectionView to allow the cell to resize.

Additionally adds an example to demonstrate this behavior.

https://user-images.githubusercontent.com/438313/177396250-705627bc-2eac-49ec-b82e-58f09fa57925.mp4

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
