### PR TITLE
[SwiftUI] Add automatic sizing option for UIKit in SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to have Swift 5.4 as the minimum supported Swift version (previously Swift 5.3).
 - Updated `HGroupView` and `VGroupView` to have `insetsLayoutMarginsFromSafeArea = false` by default
 - Gated an old autoresizing-mask-related bug workaround to only run on iOS versions 13 and below
+- The `swiftUIView(…)` methods now default to an automatic sizing behavior that makes a best effort
+  at sizing the view based on heuristics, rather than defaulting to intrinsic height and proposed 
+  width.
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09
 

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -83,7 +83,7 @@ extension StyledView
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  /// The sizing defaults to `.intrinsicHeightProposedWidth`.
+  /// The sizing defaults to `.automatic`.
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil)
@@ -115,10 +115,10 @@ extension StyledView
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  /// The sizing defaults to `.intrinsicHeightProposedWidth`.
+  /// The sizing defaults to `.automatic`.
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerStrategy = .intrinsicHeightProposedWidth)
+    sizing: SwiftUIMeasurementContainerStrategy = .automatic)
     -> SwiftUIStylelessContentlessEpoxyableView<Self>
   {
     .init(behaviors: behaviors, sizing: sizing)
@@ -135,7 +135,7 @@ public struct SwiftUIEpoxyableView<View>: MeasuringUIViewRepresentable, UIViewCo
   var content: View.Content
   var style: View.Style
   var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.intrinsicHeightProposedWidth
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
   public var configurations: [(View) -> Void] = []
 
   public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
@@ -189,7 +189,7 @@ public struct SwiftUIStylelessEpoxyableView<View>: MeasuringUIViewRepresentable,
 {
   var content: View.Content
   var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.intrinsicHeightProposedWidth
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
   public var configurations: [(View) -> Void] = []
 
   public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
@@ -234,7 +234,7 @@ public struct SwiftUIContentlessEpoxyableView<View>: MeasuringUIViewRepresentabl
 {
   var style: View.Style
   var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.intrinsicHeightProposedWidth
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
   public var configurations: [(View) -> Void] = []
 
   public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
@@ -278,7 +278,7 @@ public struct SwiftUIStylelessContentlessEpoxyableView<View>: MeasuringUIViewRep
 {
   public var configurations: [(View) -> Void] = []
   var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.intrinsicHeightProposedWidth
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
 
   public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
     wrapper.view = self

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -23,7 +23,7 @@ extension UIViewProtocol {
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  /// The sizing defaults to `.intrinsicHeightProposedWidth`.
+  /// The sizing defaults to `.automatic`.
   public static func swiftUIView(makeView: @escaping () -> Self) -> SwiftUIUIView<Self> {
     SwiftUIUIView(makeView: makeView)
   }
@@ -42,7 +42,7 @@ public struct SwiftUIUIView<View: UIView>: MeasuringUIViewRepresentable, UIViewC
   public var configurations: [(View) -> Void] = []
 
   /// The sizing context used to size the represented view.
-  public var sizing = SwiftUIMeasurementContainerStrategy.intrinsicHeightProposedWidth
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
 
   public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
     SwiftUIMeasurementContainer(


### PR DESCRIPTION
## Change summary
Adds a new `.automatic` sizing behavior for SwiftUI views embedded in Epoxy where the container makes a best effort to correctly choose the measurement strategy of the view based on a number of heuristics:
- The `UIView` will be given its intrinsic width and/or height when measurement in that dimension produces a positive value, while zero/negative values will result in that dimension receiving the available space proposed by the parent.
- If the view contains `UILabel` subviews that require a double layout pass as determined by a `preferredMaxLayoutWidth` that's greater than zero after a layout, then the view will default to `intrinsicHeightProposedWidth` to allow the labels to wrap.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
