### PR TITLE
Fix issue where EpoxyLogger asserts would unexpectedly crash in release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gracefully support cases where a `SwiftUIMeasurementContainer` with an `intrinsicSize`
   `SwiftUIMeasurementContainerStrategy` has an intrinsic size that exceeds the proposed size by
   compressing rather than overflowing, which could result in broken layouts.
-- Fixed intrinsic size invalidation triggered by a SwiftUI view from within a collection view 
+- Fixed intrinsic size invalidation triggered by a SwiftUI view from within a collection view
   cell by invalidating the enclosing collection view layout.
+- Fixed an issue where `EpoxyLogger.shared.assertionFailure` and `EpoxyLogger.shared.assert` would
+  unexpectedly crash in release builds.
 
 ### Changed
 - Updated name of `Spacer` to `LayoutSpacer` to avoid name conflict with SwiftUI's `Spacer`

--- a/Sources/EpoxyCore/Logging/EpoxyLogger.swift
+++ b/Sources/EpoxyCore/Logging/EpoxyLogger.swift
@@ -8,8 +8,19 @@ public final class EpoxyLogger {
   // MARK: Lifecycle
 
   public init(
-    assert: @escaping Assert = Swift.assert,
-    assertionFailure: @escaping AssertionFailure = Swift.assertionFailure,
+    assert: @escaping Assert = { condition, message, file, line in
+      // If we default to `Swift.assert` directly with `assert: Assert = Swift.assert`,
+      // the call will unexpectedly not respect the -O flag and will crash in release
+      // https://github.com/apple/swift/issues/60249
+      Swift.assert(condition(), message(), file: file, line: line)
+    },
+    assertionFailure: @escaping AssertionFailure = { message, file, line in
+      // If we default to `Swift.assertionFailure` directly with
+      // `assertionFailure: AssertionFailure = Swift.assertionFailure`,
+      // the call will unexpectedly not respect the -O flag and will crash in release
+      // https://github.com/apple/swift/issues/60249
+      Swift.assertionFailure(message(), file: file, line: line)
+    },
     warn: @escaping Warn = { message, _, _ in
       #if DEBUG
       // swiftlint:disable:next no_direct_standard_out_logs


### PR DESCRIPTION
## Change summary
In the same style as https://github.com/airbnb/lottie-ios/pull/1665, fixes an issue where `EpoxyLogger.shared.assertionFailure` and `EpoxyLogger.shared.assert` would unexpectedly crash in release builds.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Tested by Cal on Lottie

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
