### PR TITLE
[SwiftUI] Improve automatic sizing heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.8.0...HEAD)
 
+### Fixed
+- Improve double layout pass heuristics for views that have intrinsic size dimensions below 1 or for
+  views that have double layout pass subviews that aren't horizontally constrained to the edges.
+
 ## [0.8.0](https://github.com/airbnb/epoxy-ios/compare/0.7.0...0.8.0) - 2022-07-28
 
 ### Added
@@ -45,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `HGroupView` and `VGroupView` to have `insetsLayoutMarginsFromSafeArea = false` by default
 - Gated an old autoresizing-mask-related bug workaround to only run on iOS versions 13 and below
 - The `swiftUIView(…)` methods now default to an automatic sizing behavior that makes a best effort
-  at sizing the view based on heuristics, rather than defaulting to intrinsic height and proposed 
+  at sizing the view based on heuristics, rather than defaulting to intrinsic height and proposed
   width.
 
 ## [0.7.0](https://github.com/airbnb/epoxy-ios/compare/0.6.0...0.7.0) - 2021-12-09

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -161,12 +161,13 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
       if intrinsicSize.width > 0, uiView.containsDoubleLayoutPassSubviews() {
         resolved = .intrinsicHeightProposedWidth
       } else {
+        let zero = CGFloat(0)
         switch (width: intrinsicSize.width, height: intrinsicSize.height) {
-        case (width: ...0, height: ...0):
+        case (width: ...zero, height: ...zero):
           resolved = .proposed
-        case (width: ...0, height: 0.nextUp...):
+        case (width: ...zero, height: zero.nextUp...):
           resolved = .intrinsicHeightProposedWidth
-        case (width: 0.nextUp..., height: ...0):
+        case (width: zero.nextUp..., height: ...zero):
           resolved = .intrinsicWidthProposedHeight
         default:
           resolved = .intrinsic(intrinsicSize)

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -156,15 +156,17 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
       // `UILabel.preferredMaxLayoutWidth`.
       let intrinsicSize = uiView.systemLayoutFittingIntrinsicSize()
 
-      if uiView.containsDoubleLayoutPassSubviews() {
+      // If the view has a intrinsic width and contains a double layout pass subview, allow it to
+      // fill the proposed width to allow the label content to wrap to multiple lines.
+      if intrinsicSize.width > 0, uiView.containsDoubleLayoutPassSubviews() {
         resolved = .intrinsicHeightProposedWidth
       } else {
         switch (width: intrinsicSize.width, height: intrinsicSize.height) {
         case (width: ...0, height: ...0):
           resolved = .proposed
-        case (width: ...0, height: 1...):
+        case (width: ...0, height: 0.nextUp...):
           resolved = .intrinsicHeightProposedWidth
-        case (width: 1..., height: ...0):
+        case (width: 0.nextUp..., height: ...0):
           resolved = .intrinsicWidthProposedHeight
         default:
           resolved = .intrinsic(intrinsicSize)

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -156,8 +156,8 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
       // `UILabel.preferredMaxLayoutWidth`.
       let intrinsicSize = uiView.systemLayoutFittingIntrinsicSize()
 
-      // If the view has a intrinsic width and contains a double layout pass subview, allow it to
-      // fill the proposed width to allow the label content to wrap to multiple lines.
+      // If the view has a intrinsic width and contains a double layout pass subview, give it the
+      // proposed width to allow the label content to gracefully wrap to multiple lines.
       if intrinsicSize.width > 0, uiView.containsDoubleLayoutPassSubviews() {
         resolved = .intrinsicHeightProposedWidth
       } else {


### PR DESCRIPTION
## Change summary
- We only want to switch to `intrinsicHeightProposedWidth` when the view has a non-zero intrinsic width _and_ has double layout pass subviews, otherwise we can errantly switch to `intrinsicHeightProposedWidth` just due to the presence of a `UILabel` subview that isn't directly or indirectly constrained to the edges of the view. This happened with our video player.
- We also want to gracefully handle views with intrinsic sizes that are smaller than 1

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
