### PR TITLE
Update HGroupItem and VGroupItem to use init(style:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improve double layout pass heuristics for views that have intrinsic size dimensions below 1 or for
   views that have double layout pass subviews that aren't horizontally constrained to the edges.
+- Fixed HGroupItem and VGroupItem not respecting some properties of the style that is passed in.
 
 ## [0.8.0](https://github.com/airbnb/epoxy-ios/compare/0.7.0...0.8.0) - 2022-07-28
 

--- a/Sources/EpoxyLayoutGroups/Models/HGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/HGroupItem.swift
@@ -100,9 +100,7 @@ extension HGroupItem: InternalGroupItemModeling {
 
   public func makeConstrainable() -> Constrainable {
     HGroup(
-      alignment: style.alignment,
-      accessibilityAlignment: style.accessibilityAlignment,
-      spacing: style.spacing,
+      style: style,
       items: groupItems)
       .reflowsForAccessibilityTypeSizes(reflowsForAccessibilityTypeSizes)
       .accessibilityAlignment(accessibilityAlignment)

--- a/Sources/EpoxyLayoutGroups/Models/VGroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Models/VGroupItem.swift
@@ -97,8 +97,7 @@ extension VGroupItem: InternalGroupItemModeling {
 
   public func makeConstrainable() -> Constrainable {
     VGroup(
-      alignment: style.alignment,
-      spacing: style.spacing,
+      style: style,
       items: groupItems)
       .accessibilityAlignment(accessibilityAlignment)
       .horizontalAlignment(horizontalAlignment)


### PR DESCRIPTION
## Change summary
This fixes https://github.com/airbnb/epoxy-ios/issues/56

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
