### PR TITLE
Add workaround for issue where airbnb/swift dependency causes Xcode to spin indefinitely at 100% CPU load

### DIFF
--- a/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,24 +36,6 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
-      },
-      {
-        "package": "AirbnbSwift",
-        "repositoryURL": "https://github.com/airbnb/swift",
-        "state": {
-          "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,24 +36,6 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
-      },
-      {
-        "package": "AirbnbSwift",
-        "repositoryURL": "https://github.com/airbnb/swift",
-        "state": {
-          "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -39,8 +39,3 @@ let package = Package(
     .testTarget(name: "EpoxyTests", dependencies: ["Epoxy", "Quick", "Nimble"]),
     .testTarget(name: "PerformanceTests", dependencies: ["EpoxyCore"]),
   ])
-
-#if swift(>=5.6)
-// Add the Airbnb Swift formatting plugin if possible
-package.dependencies.append(.package(url: "https://github.com/airbnb/swift", from: "1.0.1"))
-#endif

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ namespace :lint do
 
   desc 'Lints swift files'
   task :swift do
-    sh 'swift package --allow-writing-to-package-directory format --lint'
+    formatTool('format --lint')
   end
 end
 
@@ -63,7 +63,7 @@ end
 namespace :format do
   desc 'Runs AirbnbSwiftFormatTool'
   task :swift do
-    sh 'swift package --allow-writing-to-package-directory format'
+    formatTool('format')
   end
 end
 
@@ -87,4 +87,45 @@ def xcodebuild(command)
   else
     sh "xcodebuild #{command}"
   end
+end
+
+def formatTool(command)
+  # As of Xcode 13.4 / Xcode 14 beta 4, including airbnb/swift as a dependency
+  # causes Xcode to spin indefinitely at 100% CPU (due to the remote binary dependencies
+  # used by that package). As a workaround, we can specifically add that dependency
+  # to our Package.swift file when linting / formatting and remove it afterwards.
+  packageDefinition = File.read('Package.swift')
+  resolvedPackages = File.read('Package.resolved')
+
+  packageDefinitionWithFormatDependency = packageDefinition +
+  <<~EOC
+  
+  #if swift(>=5.6)
+  // Add the Airbnb Swift formatting plugin if possible
+  package.dependencies.append(
+    .package(
+      url: "https://github.com/airbnb/swift",
+      // Since we don't have a Package.resolved entry for this, we need to reference a specific commit
+      // so changes to the style guide don't cause this repo's checks to start failing.
+      .revision("cec29280c35dd6eccba415fa3bfc24c819eae887")))
+  #endif
+  EOC
+
+  # Add the format tool dependency to our Package.swift
+  File.write('Package.swift', packageDefinitionWithFormatDependency)
+
+  exitCode = 0
+
+  # Run the given command
+  begin
+    sh "swift package --allow-writing-to-package-directory #{command}"
+  rescue
+    exitCode = $?.exitstatus
+  ensure
+    # Revert the changes to Package.swift and Package.resolved
+    File.write('Package.swift', packageDefinition)
+    File.write('Package.resolved', resolvedPackages)
+  end
+
+  exit exitCode
 end


### PR DESCRIPTION
This PR adds a workaround for issue where our dependency on the [airbnb/swift repo](https://github.com/airbnb/swift) causes Xcode to spin indefinitely at 100% CPU load. As discussed in https://github.com/airbnb/swift/pull/183 this is caused by the remote binary dependencies that package uses.

As a workaround, we can remove that dependency from our `Package.swift`. When running `bundle exec rake format:swift` / `bundle exec rake lint:swift`, we can temporarily add the dependency, run the linter/formatter, and then remove the dependency. 