### PR TITLE
[SwiftUI] Improve intrinsic sizing behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.8.0...HEAD)
 
 ### Fixed
-- Improve double layout pass heuristics for views that have intrinsic size dimensions below 1 or for
-  views that have double layout pass subviews that aren't horizontally constrained to the edges.
+- Improved double layout pass heuristics for views that have intrinsic size dimensions below 1 or 
+  for views that have double layout pass subviews that aren't horizontally constrained to the edges.
 - Fixed HGroupItem and VGroupItem not respecting some properties of the style that is passed in.
+- Improved sizing of intrinsically sized UIViews in SwiftUI with no intrinsic metric size proposals.
 
 ## [0.8.0](https://github.com/airbnb/epoxy-ios/compare/0.7.0...0.8.0) - 2022-07-28
 

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -251,13 +251,19 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
     case .intrinsic(let size):
       measuredSize = size
 
-      // If the measured size exceeds the available width or height, set the measured size to
+      // If the measured size exceeds an available width or height, set the measured size to
       // `noIntrinsicMetric` to ensure that the component can be compressed, otherwise it will
       // overflow beyond the proposed size.
-      if measuredSize.width > proposedSizeElseBounds.width {
+      if
+        proposedSize.width != UIView.noIntrinsicMetric,
+        measuredSize.width > proposedSizeElseBounds.width
+      {
         measuredSize.width = UIView.noIntrinsicMetric
       }
-      if measuredSize.height > proposedSizeElseBounds.height {
+      if
+        proposedSize.height != UIView.noIntrinsicMetric,
+        measuredSize.height > proposedSizeElseBounds.height
+      {
         measuredSize.height = UIView.noIntrinsicMetric
       }
     }


### PR DESCRIPTION
## Change summary
Improved sizing of intrinsically sized UIViews in SwiftUI with no intrinsic metric size proposals.

As-is, this results in some intrinsically sized views to be compressed to zero size height in certain cases on iOS 16 Beta 5.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
