### PR TITLE
[SwiftUI] Fix bug that could prevent size changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for views that have double layout pass subviews that aren't horizontally constrained to the edges.
 - Fixed HGroupItem and VGroupItem not respecting some properties of the style that is passed in.
 - Improved sizing of intrinsically sized UIViews in SwiftUI with no intrinsic metric size proposals.
+- Add extra logic for mitigating proposed sizes that match previous intrinsic size for hosted 
+  UIViews in SwiftUI.
 
 ## [0.8.0](https://github.com/airbnb/epoxy-ios/compare/0.7.0...0.8.0) - 2022-07-28
 

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -254,15 +254,21 @@ public final class SwiftUIMeasurementContainer<SwiftUIView, UIViewType: UIView>:
       // If the measured size exceeds an available width or height, set the measured size to
       // `noIntrinsicMetric` to ensure that the component can be compressed, otherwise it will
       // overflow beyond the proposed size.
+      // - If the previous intrinsic content size is the same as the new proposed size, we don't
+      //   do this as SwiftUI sometimes "proposes" the same intrinsic size back to the component and
+      //   we don't want that scenario to prevent size changes when there is actually more space
+      //   available.
       if
         proposedSize.width != UIView.noIntrinsicMetric,
-        measuredSize.width > proposedSizeElseBounds.width
+        measuredSize.width > proposedSizeElseBounds.width,
+        _intrinsicContentSize.width != proposedSize.width
       {
         measuredSize.width = UIView.noIntrinsicMetric
       }
       if
         proposedSize.height != UIView.noIntrinsicMetric,
-        measuredSize.height > proposedSizeElseBounds.height
+        measuredSize.height > proposedSizeElseBounds.height,
+        _intrinsicContentSize.height != proposedSize.height
       {
         measuredSize.height = UIView.noIntrinsicMetric
       }


### PR DESCRIPTION
## Change summary
Add extra logic for proposed sizes that match previous intrinsic size.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
