### PR TITLE
[SwiftUI] Simplify UIKit in SwiftUI briding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.8.0...HEAD)
 
+### Changed
+- Remove all of the `EpoxyableView` flavors of `MeasuringUIViewRepresentable` in favor of a 
+  single shared `SwiftUIUIView` that supports a generic `Storage`, which has the added benefit of 
+  fixing some Xcode preview crashes.
+
 ### Fixed
 - Improved double layout pass heuristics for views that have intrinsic size dimensions below 1 or 
   for views that have double layout pass subviews that aren't horizontally constrained to the edges.

--- a/Example/EpoxyExample/ViewControllers/SwiftUI/EpoxyInSwiftUIViewController.swift
+++ b/Example/EpoxyExample/ViewControllers/SwiftUI/EpoxyInSwiftUIViewController.swift
@@ -27,9 +27,9 @@ struct EpoxyInSwiftUIView: View {
           TextRow.swiftUIView(
             content: .init(title: "Row \(index)", body: BeloIpsum.sentence(count: 1, wordCount: index)),
             style: .small)
-            .configure { row in
+            .configure { context in
               // swiftlint:disable:next no_direct_standard_out_logs
-              print("Configuring \(row)")
+              print("Configuring \(context.view)")
             }
             .onTapGesture {
               // swiftlint:disable:next no_direct_standard_out_logs

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -26,9 +26,26 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil)
-    -> SwiftUIEpoxyableView<Self>
+    -> SwiftUIUIView<Self, (content: Content, style: Style)>
   {
-    .init(content: content, style: style, behaviors: behaviors)
+    SwiftUIUIView(storage: (content: content, style: style)) {
+      let view = Self(style: style)
+      view.setContent(content, animated: false)
+      return view
+    }
+    .configure { context in
+      // We need to create a new view instance when the style changes.
+      if context.oldStorage.style != style {
+        context.view = Self(style: style)
+        context.view.setContent(content, animated: context.animated)
+      }
+      // Otherwise, if the just the content changes, we need to update it.
+      else if context.oldStorage.content != content {
+        context.view.setContent(content, animated: context.animated)
+      }
+
+      context.view.setBehaviors(behaviors)
+    }
   }
 }
 
@@ -56,9 +73,22 @@ extension StyledView
   public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil)
-    -> SwiftUIStylelessEpoxyableView<Self>
+    -> SwiftUIUIView<Self, Content>
   {
-    .init(content: content, behaviors: behaviors)
+    SwiftUIUIView(storage: content) {
+      let view = Self()
+      view.setContent(content, animated: false)
+      return view
+    }
+    .configure { context in
+      context.view.setBehaviors(behaviors)
+
+      // We need to update the content of the existing view when the content is updated.
+      if context.oldStorage != content {
+        context.view.setContent(content, animated: context.animated)
+        context.view.superview?.invalidateIntrinsicContentSize()
+      }
+    }
   }
 }
 
@@ -87,9 +117,19 @@ extension StyledView
   public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil)
-    -> SwiftUIContentlessEpoxyableView<Self>
+    -> SwiftUIUIView<Self, Style>
   {
-    .init(style: style, behaviors: behaviors)
+    SwiftUIUIView(storage: style) {
+      Self(style: style)
+    }
+    .configure { context in
+      // We need to create a new view instance when the style changes.
+      if context.oldStorage != style {
+        context.view = Self(style: style)
+      }
+
+      context.view.setBehaviors(behaviors)
+    }
   }
 }
 
@@ -118,180 +158,14 @@ extension StyledView
   /// The sizing defaults to `.automatic`.
   public static func swiftUIView(
     behaviors: Behaviors? = nil,
-    sizing: SwiftUIMeasurementContainerStrategy = .automatic)
-    -> SwiftUIStylelessContentlessEpoxyableView<Self>
+    sizing _: SwiftUIMeasurementContainerStrategy = .automatic)
+    -> SwiftUIUIView<Self, Void>
   {
-    .init(behaviors: behaviors, sizing: sizing)
-  }
-}
-
-// MARK: - SwiftUIEpoxyableView
-
-/// A SwiftUI `View` representing an `EpoxyableView` with content, behaviors, and style.
-public struct SwiftUIEpoxyableView<View>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView
-  where
-  View: EpoxyableView
-{
-  var content: View.Content
-  var style: View.Style
-  var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
-  public var configurations: [(View) -> Void] = []
-
-  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
-    let animated = context.transaction.animation != nil
-
-    defer {
-      wrapper.view = self
-
-      // We always update the view behaviors on every view update.
-      wrapper.uiView.setBehaviors(behaviors)
-
-      for configuration in configurations {
-        configuration(wrapper.uiView)
-      }
+    SwiftUIUIView {
+      Self()
     }
-
-    // We need to create a new view instance when the style is updated.
-    guard wrapper.view.style == style else {
-      let uiView = View(style: style)
-      uiView.setContent(content, animated: false)
-      uiView.setBehaviors(behaviors)
-      wrapper.uiView = uiView
-      return
+    .configure { context in
+      context.view.setBehaviors(behaviors)
     }
-
-    // We need to update the content of the existing view when the content is updated.
-    guard wrapper.view.content == content else {
-      wrapper.uiView.setContent(content, animated: animated)
-      wrapper.invalidateIntrinsicContentSize()
-      return
-    }
-
-    // No updates required.
-  }
-
-  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
-    let uiView = View(style: style)
-    uiView.setContent(content, animated: false)
-    // No need to set behaviors as `updateUIView` is called immediately after construction.
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, strategy: sizing)
-  }
-}
-
-// MARK: - SwiftUIStylelessEpoxyableView
-
-/// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style`.
-public struct SwiftUIStylelessEpoxyableView<View>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView
-  where
-  View: EpoxyableView,
-  View.Style == Never
-{
-  var content: View.Content
-  var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
-  public var configurations: [(View) -> Void] = []
-
-  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context: Context) {
-    let animated = context.transaction.animation != nil
-
-    defer {
-      wrapper.view = self
-
-      // We always update the view behaviors on every view update.
-      wrapper.uiView.setBehaviors(behaviors)
-
-      for configuration in configurations {
-        configuration(wrapper.uiView)
-      }
-    }
-
-    // We need to update the content of the existing view when the content is updated.
-    guard wrapper.view.content == content else {
-      wrapper.uiView.setContent(content, animated: animated)
-      wrapper.invalidateIntrinsicContentSize()
-      return
-    }
-
-    // No updates required.
-  }
-
-  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
-    let uiView = View()
-    uiView.setContent(content, animated: false)
-    // No need to set behaviors as `updateUIView` is called immediately after construction.
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, strategy: sizing)
-  }
-}
-
-// MARK: - SwiftUIContentlessEpoxyableView
-
-/// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Content`.
-public struct SwiftUIContentlessEpoxyableView<View>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView
-  where
-  View: EpoxyableView,
-  View.Content == Never
-{
-  var style: View.Style
-  var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
-  public var configurations: [(View) -> Void] = []
-
-  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
-    defer {
-      wrapper.view = self
-
-      // We always update the view behaviors on every view update.
-      wrapper.uiView.setBehaviors(behaviors)
-
-      for configuration in configurations {
-        configuration(wrapper.uiView)
-      }
-    }
-
-    // We need to create a new view instance when the style is updated.
-    guard wrapper.view.style == style else {
-      let uiView = View(style: style)
-      uiView.setBehaviors(behaviors)
-      wrapper.uiView = uiView
-      return
-    }
-
-    // No updates required.
-  }
-
-  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
-    let uiView = View(style: style)
-    // No need to set behaviors as `updateUIView` is called immediately after construction.
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, strategy: sizing)
-  }
-}
-
-// MARK: - SwiftUIStylelessContentlessEpoxyableView
-
-/// A SwiftUI `View` representing an `EpoxyableView` with a `Never` `Style` and `Content`.
-public struct SwiftUIStylelessContentlessEpoxyableView<View>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView
-  where
-  View: EpoxyableView,
-  View.Content == Never,
-  View.Style == Never
-{
-  public var configurations: [(View) -> Void] = []
-  var behaviors: View.Behaviors?
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
-
-  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
-    wrapper.view = self
-    wrapper.uiView.setBehaviors(behaviors)
-
-    for configuration in configurations {
-      configuration(wrapper.uiView)
-    }
-  }
-
-  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
-    let uiView = View()
-    // No need to set behaviors as `updateUIView` is called immediately after construction.
-    return SwiftUIMeasurementContainer(view: self, uiView: uiView, strategy: sizing)
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -12,8 +12,8 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
   /// returned SwiftUI `View`:
   /// ```
   /// MyView.swiftUIView(…)
-  ///   .configure { (view: MyView) in
-  ///     …
+  ///   .configure { context in
+  ///     context.view.doSomething()
   ///   }
   /// ```
   ///
@@ -42,6 +42,7 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
       // Otherwise, if the just the content changes, we need to update it.
       else if context.oldStorage.content != content {
         context.view.setContent(content, animated: context.animated)
+        context.container.invalidateIntrinsicContentSize()
       }
 
       context.view.setBehaviors(behaviors)
@@ -60,8 +61,8 @@ extension StyledView
   /// returned SwiftUI `View`:
   /// ```
   /// MyView.swiftUIView(…)
-  ///   .configure { (view: MyView) in
-  ///     …
+  ///   .configure { context in
+  ///     context.view.doSomething()
   ///   }
   /// ```
   ///
@@ -81,13 +82,13 @@ extension StyledView
       return view
     }
     .configure { context in
-      context.view.setBehaviors(behaviors)
-
       // We need to update the content of the existing view when the content is updated.
       if context.oldStorage != content {
         context.view.setContent(content, animated: context.animated)
-        context.view.superview?.invalidateIntrinsicContentSize()
+        context.container.invalidateIntrinsicContentSize()
       }
+
+      context.view.setBehaviors(behaviors)
     }
   }
 }
@@ -103,8 +104,8 @@ extension StyledView
   /// returned SwiftUI `View`:
   /// ```
   /// MyView.swiftUIView(…)
-  ///   .configure { (view: MyView) in
-  ///     …
+  ///   .configure { context in
+  ///     context.view.doSomething()
   ///   }
   /// ```
   ///
@@ -145,8 +146,8 @@ extension StyledView
   /// returned SwiftUI `View`:
   /// ```
   /// MyView.swiftUIView(…)
-  ///   .configure { (view: MyView) in
-  ///     …
+  ///   .configure { context in
+  ///     context.view.doSomething()
   ///   }
   /// ```
   ///
@@ -156,11 +157,7 @@ extension StyledView
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public static func swiftUIView(
-    behaviors: Behaviors? = nil,
-    sizing _: SwiftUIMeasurementContainerStrategy = .automatic)
-    -> SwiftUIUIView<Self, Void>
-  {
+  public static func swiftUIView(behaviors: Behaviors? = nil) -> SwiftUIUIView<Self, Void> {
     SwiftUIUIView {
       Self()
     }

--- a/Sources/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringUIViewRepresentable.swift
+++ b/Sources/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringUIViewRepresentable.swift
@@ -14,10 +14,10 @@ import SwiftUI
 /// - SeeAlso: ``SwiftUIMeasurementContainer``
 public protocol MeasuringUIViewRepresentable: UIViewRepresentable
   where
-  UIViewType == SwiftUIMeasurementContainer<Self, View>
+  UIViewType == SwiftUIMeasurementContainer<Content>
 {
-  /// The `UIView` that's being measured by the enclosing `SwiftUIMeasurementContainer`.
-  associatedtype View: UIView
+  /// The `UIView` content that's being measured by the enclosing `SwiftUIMeasurementContainer`.
+  associatedtype Content: UIView
 
   /// The sizing strategy of the represented view.
   ///

--- a/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
@@ -42,7 +42,8 @@ public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresenta
     let oldStorage = context.coordinator.storage
     context.coordinator.storage = storage
 
-    let configurationContext = ConfigurationContext(oldStorage: oldStorage,
+    let configurationContext = ConfigurationContext(
+      oldStorage: oldStorage,
       viewRepresentableContext: context,
       container: uiView)
 
@@ -61,12 +62,22 @@ public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresenta
   var makeContent: () -> Content
 }
 
-// MARK: - SwiftUIUIView.ConfigurationContext
+// MARK: SwiftUIUIView.ConfigurationContext
 
 extension SwiftUIUIView {
   /// The configuration context that's available to configure the `Content` view whenever the
   /// `updateUIView()` method is invoked via a configuration closure.
   public struct ConfigurationContext: ViewProviding {
+    /// The previous value for the `Storage` of this `SwiftUIUIView`, which can be used to store
+    /// values across state changes to prevent redundant view updates.
+    public var oldStorage: Storage
+
+    /// The `UIViewRepresentable.Context`, with information about the transaction and environment.
+    public var viewRepresentableContext: Context
+
+    /// The backing measurement container that contains the `Content`.
+    public var container: SwiftUIMeasurementContainer<Content>
+
     /// The `UIView` that's being configured.
     ///
     /// Setting this to a new value updates the backing measurement container's `content`.
@@ -75,24 +86,15 @@ extension SwiftUIUIView {
       nonmutating set { container.content = newValue }
     }
 
-    /// The previous value for the `Storage` of this `SwiftUIUIView`, which can be used to store
-    /// values across state changes to prevent redundant view updates.
-    public var oldStorage: Storage
-
-    /// The `UIViewRepresentable.Context`, with information about the transaction and environment.
-    public var viewRepresentableContext: Context
-
     /// A convenience accessor indicating whether this content update was animated.
     public var animated: Bool {
       viewRepresentableContext.transaction.animation != nil
     }
 
-    /// The backing measurement container that contains the `Content`.
-    public var container: SwiftUIMeasurementContainer<Content>
   }
 }
 
-// MARK: - SwiftUIUIView.Coordinator
+// MARK: SwiftUIUIView.Coordinator
 
 extension SwiftUIUIView {
   /// A coordinator that stores the `storage` associated with this view.

--- a/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
@@ -8,15 +8,24 @@ import SwiftUI
 /// A `UIViewRepresentable` SwiftUI `View` that wraps its `Content` `UIView` within a
 /// `SwiftUIMeasurementContainer`, used to size a UIKit view correctly within a SwiftUI view
 /// hierarchy.
-public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView {
+///
+/// Includes an optional generic `Storage` value, which can be used to compare old and new values
+/// across state changes to prevent redundant view updates.
+public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresentable,
+  UIViewConfiguringSwiftUIView
+{
 
   // MARK: Lifecycle
 
+  /// Creates a SwiftUI representation of the content view with the given storage and the provided
+  /// `makeContent` closure to construct the content whenever `makeUIView(…)` is invoked.
   init(storage: Storage, makeContent: @escaping () -> Content) {
     self.storage = storage
     self.makeContent = makeContent
   }
 
+  /// Creates a SwiftUI representation of the content view with the provided `makeContent` closure
+  /// to construct it whenever `makeUIView(…)` is invoked.
   init(makeContent: @escaping () -> Content) where Storage == Void {
     storage = ()
     self.makeContent = makeContent
@@ -24,12 +33,23 @@ public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresenta
 
   // MARK: Public
 
-  /// An array of closures that are invoked to configure the represented view.
-  public var configurations: [(ConfigurationContext) -> Void] = []
+  public var configurations: [Configuration] = []
 
-  /// The sizing context used to size the represented view.
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
+  public var sizing: SwiftUIMeasurementContainerStrategy = .automatic
 
+  // MARK: Private
+
+  /// The current stored value, with the previous value provided to the configuration closure as
+  /// the `oldStorage`.
+  private var storage: Storage
+
+  /// A closure that's invoked to construct the represented content view.
+  private var makeContent: () -> Content
+}
+
+// MARK: UIViewRepresentable
+
+extension SwiftUIUIView {
   public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Content> {
     SwiftUIMeasurementContainer(content: makeContent(), strategy: sizing)
   }
@@ -51,15 +71,6 @@ public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresenta
       configuration(configurationContext)
     }
   }
-
-  // MARK: Internal
-
-  /// The current stored value, with the previous value provided to the configuration closure as
-  /// the `oldStorage`.
-  var storage: Storage
-
-  /// A closure that's invoked to construct the represented view.
-  var makeContent: () -> Content
 }
 
 // MARK: SwiftUIUIView.ConfigurationContext
@@ -78,7 +89,7 @@ extension SwiftUIUIView {
     /// The backing measurement container that contains the `Content`.
     public var container: SwiftUIMeasurementContainer<Content>
 
-    /// The `UIView` that's being configured.
+    /// The `UIView` content that's being configured.
     ///
     /// Setting this to a new value updates the backing measurement container's `content`.
     public var view: Content {
@@ -86,28 +97,28 @@ extension SwiftUIUIView {
       nonmutating set { container.content = newValue }
     }
 
-    /// A convenience accessor indicating whether this content update was animated.
+    /// A convenience accessor indicating whether this content update should be animated.
     public var animated: Bool {
       viewRepresentableContext.transaction.animation != nil
     }
-
   }
 }
 
 // MARK: SwiftUIUIView.Coordinator
 
 extension SwiftUIUIView {
-  /// A coordinator that stores the `storage` associated with this view.
+  /// A coordinator that stores the `storage` associated with this view, enabling the old storage
+  /// value to be accessed during the `updateUIView(…)`.
   public final class Coordinator {
 
     // MARK: Lifecycle
 
-    init(storage: Storage) {
+    fileprivate init(storage: Storage) {
       self.storage = storage
     }
 
     // MARK: Internal
 
-    var storage: Storage
+    fileprivate(set) var storage: Storage
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/SwiftUIUIView.swift
@@ -1,0 +1,111 @@
+// Created by eric_horacek on 9/8/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import SwiftUI
+
+// MARK: - SwiftUIUIView
+
+/// A `UIViewRepresentable` SwiftUI `View` that wraps its `Content` `UIView` within a
+/// `SwiftUIMeasurementContainer`, used to size a UIKit view correctly within a SwiftUI view
+/// hierarchy.
+public struct SwiftUIUIView<Content: UIView, Storage>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView {
+
+  // MARK: Lifecycle
+
+  init(storage: Storage, makeContent: @escaping () -> Content) {
+    self.storage = storage
+    self.makeContent = makeContent
+  }
+
+  init(makeContent: @escaping () -> Content) where Storage == Void {
+    storage = ()
+    self.makeContent = makeContent
+  }
+
+  // MARK: Public
+
+  /// An array of closures that are invoked to configure the represented view.
+  public var configurations: [(ConfigurationContext) -> Void] = []
+
+  /// The sizing context used to size the represented view.
+  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
+
+  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Content> {
+    SwiftUIMeasurementContainer(content: makeContent(), strategy: sizing)
+  }
+
+  public func makeCoordinator() -> Coordinator {
+    Coordinator(storage: storage)
+  }
+
+  public func updateUIView(_ uiView: SwiftUIMeasurementContainer<Content>, context: Context) {
+    let oldStorage = context.coordinator.storage
+    context.coordinator.storage = storage
+
+    let configurationContext = ConfigurationContext(oldStorage: oldStorage,
+      viewRepresentableContext: context,
+      container: uiView)
+
+    for configuration in configurations {
+      configuration(configurationContext)
+    }
+  }
+
+  // MARK: Internal
+
+  /// The current stored value, with the previous value provided to the configuration closure as
+  /// the `oldStorage`.
+  var storage: Storage
+
+  /// A closure that's invoked to construct the represented view.
+  var makeContent: () -> Content
+}
+
+// MARK: - SwiftUIUIView.ConfigurationContext
+
+extension SwiftUIUIView {
+  /// The configuration context that's available to configure the `Content` view whenever the
+  /// `updateUIView()` method is invoked via a configuration closure.
+  public struct ConfigurationContext: ViewProviding {
+    /// The `UIView` that's being configured.
+    ///
+    /// Setting this to a new value updates the backing measurement container's `content`.
+    public var view: Content {
+      get { container.content }
+      nonmutating set { container.content = newValue }
+    }
+
+    /// The previous value for the `Storage` of this `SwiftUIUIView`, which can be used to store
+    /// values across state changes to prevent redundant view updates.
+    public var oldStorage: Storage
+
+    /// The `UIViewRepresentable.Context`, with information about the transaction and environment.
+    public var viewRepresentableContext: Context
+
+    /// A convenience accessor indicating whether this content update was animated.
+    public var animated: Bool {
+      viewRepresentableContext.transaction.animation != nil
+    }
+
+    /// The backing measurement container that contains the `Content`.
+    public var container: SwiftUIMeasurementContainer<Content>
+  }
+}
+
+// MARK: - SwiftUIUIView.Coordinator
+
+extension SwiftUIUIView {
+  /// A coordinator that stores the `storage` associated with this view.
+  public final class Coordinator {
+
+    // MARK: Lifecycle
+
+    init(storage: Storage) {
+      self.storage = storage
+    }
+
+    // MARK: Internal
+
+    var storage: Storage
+  }
+}

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -13,8 +13,8 @@ extension UIViewProtocol {
   /// returned SwiftUI `View`:
   /// ```
   /// MyUIView.swiftUIView(…)
-  ///   .configure { (view: MyUIView) in
-  ///     …
+  ///   .configure { context in
+  ///     context.view.doSomething()
   ///   }
   /// ```
   ///

--- a/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -24,45 +24,9 @@ extension UIViewProtocol {
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public static func swiftUIView(makeView: @escaping () -> Self) -> SwiftUIUIView<Self> {
-    SwiftUIUIView(makeView: makeView)
+  public static func swiftUIView(makeView: @escaping () -> Self) -> SwiftUIUIView<Self, Void> {
+    SwiftUIUIView(makeContent: makeView)
   }
-}
-
-// MARK: - SwiftUIUIView
-
-/// A `UIViewRepresentable` SwiftUI `View` that wraps its `Content` `UIView` within a
-/// `SwiftUIMeasurementContainer`, used to size a UIKit view correctly within a SwiftUI view
-/// hierarchy.
-public struct SwiftUIUIView<View: UIView>: MeasuringUIViewRepresentable, UIViewConfiguringSwiftUIView {
-
-  // MARK: Public
-
-  /// An array of closures that are invoked to configure the represented view.
-  public var configurations: [(View) -> Void] = []
-
-  /// The sizing context used to size the represented view.
-  public var sizing = SwiftUIMeasurementContainerStrategy.automatic
-
-  public func makeUIView(context _: Context) -> SwiftUIMeasurementContainer<Self, View> {
-    SwiftUIMeasurementContainer(
-      view: self,
-      uiView: makeView(),
-      strategy: sizing)
-  }
-
-  public func updateUIView(_ wrapper: SwiftUIMeasurementContainer<Self, View>, context _: Context) {
-    wrapper.view = self
-
-    for configuration in configurations {
-      configuration(wrapper.uiView)
-    }
-  }
-
-  // MARK: Internal
-
-  /// A closure that's invoked to construct the represented view.
-  var makeView: () -> View
 }
 
 // MARK: - UIViewProtocol

--- a/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -5,15 +5,19 @@ import SwiftUI
 
 // MARK: - UIViewConfiguringSwiftUIView
 
-/// A protocol describing a SwiftUI `View` that can configure its `UIView` contents via an array of
+/// A protocol describing a SwiftUI `View` that can configure its `UIView` content via an array of
 /// `configuration` closures.
 public protocol UIViewConfiguringSwiftUIView: View {
-  /// The context available to this configuration.
+  /// The context available to this configuration, which provides the `UIView` instance at a minimum
+  /// but can include additional context as needed.
   associatedtype ConfigurationContext: ViewProviding
 
-  /// A mutable array of configuration closures that should each be invoked with the represented
-  /// `UIView` whenever `updateUIView` is called in a `UIViewRepresentable`.
-  var configurations: [(ConfigurationContext) -> Void] { get set }
+  /// A closure that is invoked to configure the represented content view.
+  typealias Configuration = (ConfigurationContext) -> Void
+
+  /// A mutable array of configuration closures that should each be invoked with the
+  /// `ConfigurationContext` whenever `updateUIView` is called in a `UIViewRepresentable`.
+  var configurations: [Configuration] { get set }
 }
 
 // MARK: Extensions
@@ -21,7 +25,7 @@ public protocol UIViewConfiguringSwiftUIView: View {
 extension UIViewConfiguringSwiftUIView {
   /// Returns a copy of this view updated to have the given closure applied to its represented view
   /// whenever it is updated via the `updateUIView(…)` method.
-  public func configure(_ configure: @escaping (ConfigurationContext) -> Void) -> Self {
+  public func configure(_ configure: @escaping Configuration) -> Self {
     var copy = self
     copy.configurations.append(configure)
     return copy
@@ -29,7 +33,7 @@ extension UIViewConfiguringSwiftUIView {
 
   /// Returns a copy of this view updated to have the given closures applied to its represented view
   /// whenever it is updated via the `updateUIView(…)` method.
-  public func configurations(_ configurations: [(ConfigurationContext) -> Void]) -> Self {
+  public func configurations(_ configurations: [Configuration]) -> Self {
     var copy = self
     copy.configurations.append(contentsOf: configurations)
     return copy

--- a/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -8,28 +8,28 @@ import SwiftUI
 /// A protocol describing a SwiftUI `View` that can configure its `UIView` contents via an array of
 /// `configuration` closures.
 public protocol UIViewConfiguringSwiftUIView: View {
-  /// The `UIView` represented by this view.
-  associatedtype View: UIView
+  /// The context available to this configuration.
+  associatedtype ConfigurationContext: ViewProviding
 
   /// A mutable array of configuration closures that should each be invoked with the represented
   /// `UIView` whenever `updateUIView` is called in a `UIViewRepresentable`.
-  var configurations: [(View) -> Void] { get set }
+  var configurations: [(ConfigurationContext) -> Void] { get set }
 }
 
 // MARK: Extensions
 
 extension UIViewConfiguringSwiftUIView {
   /// Returns a copy of this view updated to have the given closure applied to its represented view
-  /// whenever it is updated via the `updateUIView` method.
-  public func configure(_ configure: @escaping (View) -> Void) -> Self {
+  /// whenever it is updated via the `updateUIView(…)` method.
+  public func configure(_ configure: @escaping (ConfigurationContext) -> Void) -> Self {
     var copy = self
     copy.configurations.append(configure)
     return copy
   }
 
   /// Returns a copy of this view updated to have the given closures applied to its represented view
-  /// whenever it is updated via the `updateUIView` method.
-  public func configurations(_ configurations: [(View) -> Void]) -> Self {
+  /// whenever it is updated via the `updateUIView(…)` method.
+  public func configurations(_ configurations: [(ConfigurationContext) -> Void]) -> Self {
     var copy = self
     copy.configurations.append(contentsOf: configurations)
     return copy


### PR DESCRIPTION
## Change summary
We can remove all of the `EpoxyableView` flavors of `MeasuringUIViewRepresentable` in favor of a single shared `SwiftUIUIView` that supports a generic `Storage`. This has the added benefit of fixing some crashes we were seeing with Xcode previews.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
