### PR TITLE
Drop Swift 5.4, update CI workflows to run on latest macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '12.5.1' # Swift 5.4
-        - '13.2' # Swift 5.5
+        - '13.2.1' # Swift 5.5
+        - '13.4.1' # Swift 5.6
+        - '14.0.1' # Swift 5.7
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -27,8 +28,9 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '12.5.1' # Swift 5.4
-        - '13.2' # Swift 5.5
+        - '13.2.1' # Swift 5.5
+        - '13.4.1' # Swift 5.6
+        - '14.0.1' # Swift 5.7
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -42,8 +44,9 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '12.5.1' # Swift 5.4
-        - '13.2' # Swift 5.5
+        - '13.2.1' # Swift 5.5
+        - '13.4.1' # Swift 5.6
+        - '14.0.1' # Swift 5.7
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -53,9 +56,7 @@ jobs:
         run: bundle exec rake test:package
 
   lint-swift:
-    # As of 7/21/22, macos-latest (macos-11) doesn't include Xcode 13.3,
-    # which is required to run the linter package plugin.
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5
-        - '13.4.1' # Swift 5.6
-        - '14.0.1' # Swift 5.7
+        - '13.2.1' # Swift 5.5 (lowest)
+        - '14.0.1' # Swift 5.7 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -28,9 +27,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5
-        - '13.4.1' # Swift 5.6
-        - '14.0.1' # Swift 5.7
+        - '13.2.1' # Swift 5.5 (lowest)
+        - '14.0.1' # Swift 5.7 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -44,9 +42,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5
-        - '13.4.1' # Swift 5.6
-        - '14.0.1' # Swift 5.7
+        - '13.2.1' # Swift 5.5  (lowest)
+        - '14.0.1' # Swift 5.7 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.9.0...HEAD)
 
+### Changed
+- Dropped support for Swift 5.4.
+
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 
 ### Changed

--- a/ConfigurePodspec.rb
+++ b/ConfigurePodspec.rb
@@ -14,7 +14,7 @@ def configure(spec:, name:, summary:, local_deps: [])
   spec.source = { git: 'https://github.com/airbnb/epoxy-ios.git', tag: version }
   spec.source_files = "Sources/#{name}/**/*.swift"
   spec.ios.deployment_target = '13.0'
-  spec.swift_versions = ['5.4']
+  spec.swift_versions = ['5.5']
 
   local_deps.each do |dep|
     spec.dependency dep, version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Tests/EpoxyTests/NavigationControllerTests/NavigationQueueSpec.swift
+++ b/Tests/EpoxyTests/NavigationControllerTests/NavigationQueueSpec.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 10/26/19.
 // Copyright © 2019 Airbnb Inc. All rights reserved.
 
+import EpoxyCore
 import Nimble
 import Quick
 import UIKit
@@ -864,15 +865,29 @@ final class NavigationQueueSpec: QuickSpec {
             }
 
             it("should throw an assertion") {
-              expect(queue.didPop([UIViewController()], animated: true, from: presenter))
-                .to(throwAssertion())
+              let previous = EpoxyLogger.shared
+              defer { EpoxyLogger.shared = previous }
+              var failures = [String]()
+              let stub = EpoxyLogger(assertionFailure: { message, _, _ in failures.append(message()) })
+              EpoxyLogger.shared = stub
+
+              expect(failures).to(beEmpty())
+              queue.didPop([UIViewController()], animated: true, from: presenter)
+              expect(failures).to(haveCount(1))
             }
           }
 
           context("with no model at the top") {
             it("should throw an assertion") {
-              expect(queue.didPop([UIViewController()], animated: true, from: presenter))
-                .to(throwAssertion())
+              let previous = EpoxyLogger.shared
+              defer { EpoxyLogger.shared = previous }
+              var failures = [String]()
+              let stub = EpoxyLogger(assertionFailure: { message, _, _ in failures.append(message()) })
+              EpoxyLogger.shared = stub
+
+              expect(failures).to(beEmpty())
+              queue.didPop([UIViewController()], animated: true, from: presenter)
+              expect(failures).to(haveCount(1))
             }
           }
         }


### PR DESCRIPTION
## Change summary
We use a new build matrix that covers Swift 5.5, 5.6, and 5.7

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ensure CI is successful

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
