### PR TITLE
Add configuredView API to SupplementaryItemModeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `UIScrollView.keyboardAdjustsBottomBarOffset` escape hatch to disable bottom bar keyboard
   avoidance for cases where the keyboard is avoided at a higher level (e.g. a
   `UIPresentationController` subclass)
+- Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
@@ -92,6 +92,10 @@ extension AnySupplementaryItemModel: InternalSupplementaryItemModeling {
     }
   }
 
+  public func configuredView(traitCollection: UITraitCollection) -> UIView {
+    model.configuredView(traitCollection: traitCollection)
+  }
+
   func handleWillDisplay(
     _ view: CollectionViewReusableView,
     traitCollection: UITraitCollection,

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/AnySupplementaryItemModel.swift
@@ -79,6 +79,10 @@ extension AnySupplementaryItemModel: InternalSupplementaryItemModeling {
     model.dataID
   }
 
+  public func configuredView(traitCollection: UITraitCollection) -> UIView {
+    model.configuredView(traitCollection: traitCollection)
+  }
+
   // MARK: Internal
 
   func configure(
@@ -90,10 +94,6 @@ extension AnySupplementaryItemModel: InternalSupplementaryItemModeling {
     if let view = reusableView.view {
       setContent?(.init(view: view, traitCollection: traitCollection, animated: animated))
     }
-  }
-
-  public func configuredView(traitCollection: UITraitCollection) -> UIView {
-    model.configuredView(traitCollection: traitCollection)
   }
 
   func handleWillDisplay(

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModel.swift
@@ -175,6 +175,17 @@ extension SupplementaryItemModel: InternalSupplementaryItemModeling {
     setContent?(.init(view: view, traitCollection: traitCollection, animated: animated))
   }
 
+  public func configuredView(traitCollection: UITraitCollection) -> UIView {
+    let view = makeView()
+    let context = CallbackContext(
+      view: view,
+      traitCollection: traitCollection,
+      animated: false)
+    setContent?(context)
+    setBehaviors?(context)
+    return view
+  }
+
   public func setBehavior(
     reusableView: CollectionViewReusableView,
     traitCollection: UITraitCollection,

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModeling.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModeling.swift
@@ -40,7 +40,7 @@ protocol InternalSupplementaryItemModeling: SupplementaryItemModeling,
   /// view.
   ///
   /// - Parameter traitCollection: The trait collection to create the view for
-  /// - Returns: The configured view for this item model.
+  /// - Returns: The configured view for this supplementary item model.
   func configuredView(traitCollection: UITraitCollection) -> UIView
 
   /// Set behaviors needed by the view.

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModeling.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SupplementaryItemModeling.swift
@@ -36,6 +36,13 @@ protocol InternalSupplementaryItemModeling: SupplementaryItemModeling,
     traitCollection: UITraitCollection,
     animated: Bool)
 
+  /// Creates view for this supplementary item. This should only be used to create a view outside of a collection
+  /// view.
+  ///
+  /// - Parameter traitCollection: The trait collection to create the view for
+  /// - Returns: The configured view for this item model.
+  func configuredView(traitCollection: UITraitCollection) -> UIView
+
   /// Set behaviors needed by the view.
   ///
   /// Called before presentation and when cells are reordered.


### PR DESCRIPTION
## Change summary

This add the equivalent API to the `ItemModeling` `configuredView(traitCollection)` method which IIUC was just an oversight when we implemented `SupplementaryItem`s.

https://github.com/airbnb/epoxy-ios/blob/42d2ad2d0f7bc78594ea5ab1534c02a2fe257601/Sources/EpoxyCollectionView/Models/ItemModel/ItemModeling.swift#L50

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ran automated tests

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
