### PR TITLE
Making remove() method public in NavigationModel struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   avoidance for cases where the keyboard is avoided at a higher level (e.g. a
   `UIPresentationController` subclass)
 - Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`
+- Changed `NavigationModel`'s `remove()` method access modifier to public (previously internal).
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyNavigationController/NavigationModel.swift
+++ b/Sources/EpoxyNavigationController/NavigationModel.swift
@@ -150,6 +150,11 @@ public struct NavigationModel {
     return copy
   }
 
+  /// Updates the underlying state backing this model to remove it.
+  public func remove() {
+    _remove()
+  }
+
   // MARK: Internal
 
   /// The identifier of this stack element that distinguishes it from other stack elements.
@@ -183,11 +188,6 @@ public struct NavigationModel {
   /// stack.
   func handleDidRemove() {
     _didRemove?()
-  }
-
-  /// Updates the underlying state backing this model to remove it.
-  func remove() {
-    _remove()
   }
 
   // MARK: Private


### PR DESCRIPTION
## Change summary

A testing scenario at Airbnb requires the NavigationModel remove() func to be made public.
The scenario consists of simulating a backwards navigation in a test that does not have the entire view hierarchy built.

@bachand and @erichoracek FYI.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ran automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
