### PR TITLE
Making handleDidRemove() method public in NavigationModel struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UIPresentationController` subclass)
 - Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`
 - Changed `NavigationModel`'s `remove()` method access modifier to public (previously internal).
+- Changed `NavigationModel`'s `handleDidRemove()` method access modifier to public (previously internal).
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyNavigationController/NavigationModel.swift
+++ b/Sources/EpoxyNavigationController/NavigationModel.swift
@@ -150,6 +150,12 @@ public struct NavigationModel {
     return copy
   }
 
+  /// Informs consumers of this model that its view controller has been removed from the navigation
+  /// stack.
+  public func handleDidRemove() {
+    _didRemove?()
+  }
+
   /// Updates the underlying state backing this model to remove it.
   public func remove() {
     _remove()
@@ -182,12 +188,6 @@ public struct NavigationModel {
   /// stack.
   func handleDidAdd(_ viewController: UIViewController) {
     _didAdd?(viewController)
-  }
-
-  /// Informs consumers of this model that its view controller has been removed from the navigation
-  /// stack.
-  func handleDidRemove() {
-    _didRemove?()
   }
 
   // MARK: Private


### PR DESCRIPTION
## Change summary

Following up on #130:
We are also confident that we'll need to make handleDidRemove() public in that test scenario as well.
The scenario consists of simulating a backwards navigation in a test that does not have the entire view hierarchy built.

@bachand and @erichoracek FYI.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [x] Ran automated tests locally
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
