### PR TITLE
Revert workaround for Xcode 14.0 SPM binary dependency issue 

### DIFF
--- a/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,6 +36,24 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
+      },
+      {
+        "package": "AirbnbSwift",
+        "repositoryURL": "https://github.com/airbnb/swift",
+        "state": {
+          "branch": null,
+          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
+        }
       }
     ]
   },

--- a/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Epoxy.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/airbnb/swift",
         "state": {
           "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
+          "revision": "07bb2e0822ca6e464bf3610ed452568931fdbf65",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,6 +36,24 @@
           "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
           "version": "4.0.0"
         }
+      },
+      {
+        "package": "AirbnbSwift",
+        "repositoryURL": "https://github.com/airbnb/swift",
+        "state": {
+          "branch": null,
+          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/airbnb/swift",
         "state": {
           "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
+          "revision": "07bb2e0822ca6e464bf3610ed452568931fdbf65",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -39,3 +39,8 @@ let package = Package(
     .testTarget(name: "EpoxyTests", dependencies: ["Epoxy", "Quick", "Nimble"]),
     .testTarget(name: "PerformanceTests", dependencies: ["EpoxyCore"]),
   ])
+
+#if swift(>=5.6)
+// Add the Airbnb Swift formatting plugin if possible
+package.dependencies.append(.package(url: "https://github.com/airbnb/swift", from: "1.0.1"))
+#endif

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ namespace :lint do
 
   desc 'Lints swift files'
   task :swift do
-    formatTool('format --lint')
+    sh 'swift package --allow-writing-to-package-directory format --lint'
   end
 end
 
@@ -63,7 +63,7 @@ end
 namespace :format do
   desc 'Runs AirbnbSwiftFormatTool'
   task :swift do
-    formatTool('format')
+    sh 'swift package --allow-writing-to-package-directory format'
   end
 end
 
@@ -87,45 +87,4 @@ def xcodebuild(command)
   else
     sh "xcodebuild #{command}"
   end
-end
-
-def formatTool(command)
-  # As of Xcode 13.4 / Xcode 14 beta 4, including airbnb/swift as a dependency
-  # causes Xcode to spin indefinitely at 100% CPU (due to the remote binary dependencies
-  # used by that package). As a workaround, we can specifically add that dependency
-  # to our Package.swift file when linting / formatting and remove it afterwards.
-  packageDefinition = File.read('Package.swift')
-  resolvedPackages = File.read('Package.resolved')
-
-  packageDefinitionWithFormatDependency = packageDefinition +
-  <<~EOC
-
-  #if swift(>=5.6)
-  // Add the Airbnb Swift formatting plugin if possible
-  package.dependencies.append(
-    .package(
-      url: "https://github.com/airbnb/swift",
-      // Since we don't have a Package.resolved entry for this, we need to reference a specific commit
-      // so changes to the style guide don't cause this repo's checks to start failing.
-      .revision("7884f265499752cc5eccaa9eba08b4a2f8b73357")))
-  #endif
-  EOC
-
-  # Add the format tool dependency to our Package.swift
-  File.write('Package.swift', packageDefinitionWithFormatDependency)
-
-  exitCode = 0
-
-  # Run the given command
-  begin
-    sh "swift package --allow-writing-to-package-directory #{command}"
-  rescue
-    exitCode = $?.exitstatus
-  ensure
-    # Revert the changes to Package.swift and Package.resolved
-    File.write('Package.swift', packageDefinition)
-    File.write('Package.resolved', resolvedPackages)
-  end
-
-  exit exitCode
 end

--- a/Sources/EpoxyNavigationController/NavigationModel.swift
+++ b/Sources/EpoxyNavigationController/NavigationModel.swift
@@ -106,7 +106,7 @@ public struct NavigationModel {
   /// Any previously added `didShow` closures are called prior to the given closure.
   public func didShow(_ didShow: @escaping ((UIViewController) -> Void)) -> NavigationModel {
     var copy = self
-    copy._didShow = { [oldDidShow = self._didShow] viewController in
+    copy._didShow = { [oldDidShow = _didShow] viewController in
       oldDidShow?(viewController)
       didShow(viewController)
     }
@@ -119,7 +119,7 @@ public struct NavigationModel {
   /// Any previously added `didHide` closures are called prior to the given closure.
   public func didHide(_ didHide: @escaping (() -> Void)) -> NavigationModel {
     var copy = self
-    copy._didHide = { [oldDidHide = self._didHide] in
+    copy._didHide = { [oldDidHide = _didHide] in
       oldDidHide?()
       didHide()
     }
@@ -131,7 +131,7 @@ public struct NavigationModel {
   /// Any previously added `didAdd` closures are called prior to the given closure.
   public func didAdd(_ didAdd: @escaping ((UIViewController) -> Void)) -> NavigationModel {
     var copy = self
-    copy._didAdd = { [oldDidAdd = self._didAdd] viewController in
+    copy._didAdd = { [oldDidAdd = _didAdd] viewController in
       oldDidAdd?(viewController)
       didAdd(viewController)
     }
@@ -143,7 +143,7 @@ public struct NavigationModel {
   /// Any previously added `didRemove` closures are called prior to the given closure.
   public func didRemove(_ didRemove: @escaping (() -> Void)) -> NavigationModel {
     var copy = self
-    copy._didRemove = { [oldDidRemove = self._didRemove] in
+    copy._didRemove = { [oldDidRemove = _didRemove] in
       oldDidRemove?()
       didRemove()
     }

--- a/Sources/EpoxyPresentations/PresentationModel.swift
+++ b/Sources/EpoxyPresentations/PresentationModel.swift
@@ -79,7 +79,7 @@ public struct PresentationModel {
   /// Any previously added `didPresent` closures are called prior to the given closure.
   public func didPresent(_ didPresent: @escaping (() -> Void)) -> PresentationModel {
     var copy = self
-    copy._didPresent = { [oldDidPresent = self._didPresent] in
+    copy._didPresent = { [oldDidPresent = _didPresent] in
       oldDidPresent?()
       didPresent()
     }
@@ -91,7 +91,7 @@ public struct PresentationModel {
   /// Any previously added `didDismiss` closures are called prior to the given closure.
   public func didDismiss(_ didDismiss: @escaping (() -> Void)) -> PresentationModel {
     var copy = self
-    copy._didDismiss = { [oldDidDismiss = self._didDismiss] in
+    copy._didDismiss = { [oldDidDismiss = _didDismiss] in
       oldDidDismiss?()
       didDismiss()
     }


### PR DESCRIPTION
This PR reverts #122, which was a workaround for an issue in Xcode 14.0 where SPM binary dependencies would cause Xcode to spin indefinitely at 100% CPU load. This has been fixed in Xcode 14.1+, so we don't need to use the workaround anymore.