### PR TITLE
[EpoxyBars] Don't apply insets when hierarchy has a 3d transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for Swift 5.4.
 - Added `UIScrollView.keyboardAdjustsBottomBarOffset` escape hatch to disable bottom bar keyboard
   avoidance for cases where the keyboard is avoided at a higher level (e.g. a
-  `UIPresentationController` subclass)
-- Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`
+  `UIPresentationController` subclass).
+- Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`.
 - Changed `NavigationModel`'s `remove()` method access modifier to public (previously internal).
-- Changed `NavigationModel`'s `handleDidRemove()` method access modifier to public (previously internal).
+- Changed `NavigationModel`'s `handleDidRemove()` method access modifier to public (previously 
+  internal).
+
+### Fixed
+- For top and bottom bars, if any view in the hierarchy has a 3D transform, wait to apply the insets 
+  as they may be incorrect.
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyBars/BarInstaller/UIScrollView+ContentOffset.swift
+++ b/Sources/EpoxyBars/BarInstaller/UIScrollView+ContentOffset.swift
@@ -1,0 +1,20 @@
+// Created by eric_horacek on 2/23/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import UIKit
+
+// MARK: - UIScrollView
+
+extension UIScrollView {
+  /// The content offset at which this scroll view is scrolled to its top.
+  @nonobjc
+  var topContentOffset: CGFloat {
+    -adjustedContentInset.top
+  }
+
+  /// The content offset at which this scroll view is scrolled to its bottom.
+  @nonobjc
+  var bottomContentOffset: CGFloat {
+    max(contentSize.height - bounds.height + adjustedContentInset.bottom, topContentOffset)
+  }
+}

--- a/Sources/EpoxyBars/BarInstaller/UIView+HasHierarchy3DTransform.swift
+++ b/Sources/EpoxyBars/BarInstaller/UIView+HasHierarchy3DTransform.swift
@@ -1,0 +1,23 @@
+// Created by eric_horacek on 2/23/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import UIKit
+
+// MARK: - UIView
+
+extension UIView {
+  /// Whether this view has a non-identity 3D transform in its view hierarchy at any point in the
+  /// given number of ancestor views.
+  @nonobjc
+  func hasHierarchy3DTransform(below ancestor: Int = 10) -> Bool {
+    guard ancestor > 0 else {
+      return false
+    }
+
+    guard CATransform3DEqualToTransform(transform3D, CATransform3DIdentity) else {
+      return true
+    }
+
+    return superview?.hasHierarchy3DTransform(below: ancestor - 1) ?? false
+  }
+}

--- a/Sources/EpoxyBars/BarInstaller/UIViewController+OriginalSafeAreaInsets.swift
+++ b/Sources/EpoxyBars/BarInstaller/UIViewController+OriginalSafeAreaInsets.swift
@@ -1,0 +1,18 @@
+// Created by eric_horacek on 2/23/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import UIKit
+
+extension UIViewController {
+  /// The original safe area inset top before the additional safe area insets are applied.
+  @nonobjc
+  var originalSafeAreaInsetTop: CGFloat {
+    view.safeAreaInsets.top - additionalSafeAreaInsets.top
+  }
+
+  /// The original safe area inset bottom before the additional safe area insets are applied.
+  @nonobjc
+  var originalSafeAreaInsetBottom: CGFloat {
+    view.safeAreaInsets.bottom - additionalSafeAreaInsets.bottom
+  }
+}

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -160,6 +160,10 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
   /// Updates the view controller insets (either safe area or scroll view content inset) in response
   /// to the safe area, center, or bounds changing.
   private func updateInsets() {
+    // If any view in the hierarchy has a 3D transform, it's not valid to apply the insets as they
+    // may be incorrect; we should wait until there is no transform to so do.
+    guard !hasHierarchy3DTransform() else { return }
+
     updateAdditionalSafeAreaInset(additionalSafeAreaInsetsBottom)
 
     // If offset from the bottom, use the original layout margins rather than the safe area margins,
@@ -169,13 +173,4 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
     setLayoutMargin(margin)
   }
 
-}
-
-// MARK: - UIViewController
-
-extension UIViewController {
-  @nonobjc
-  fileprivate var originalSafeAreaInsetBottom: CGFloat {
-    view.safeAreaInsets.bottom - additionalSafeAreaInsets.bottom
-  }
 }

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -191,6 +191,10 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
   ///
   /// Additionally keeps the scroll views pinned to their current offsets during the inset changes.
   private func updateInsets() {
+    // If any view in the hierarchy has a 3D transform, it's not valid to apply the insets as they
+    // may be incorrect; we should wait until there is no transform to so do.
+    guard !hasHierarchy3DTransform() else { return }
+
     let scrollViewsAtEdge = scrollViewsAtEdge
 
     updateAdditionalSafeAreaInset(additionalSafeAreaInsetsTop)
@@ -237,29 +241,4 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
     viewController?.view.layoutIfNeeded()
   }
 
-}
-
-// MARK: - UIViewController
-
-extension UIViewController {
-  @nonobjc
-  fileprivate var originalSafeAreaInsetTop: CGFloat {
-    view.safeAreaInsets.top - additionalSafeAreaInsets.top
-  }
-}
-
-// MARK: - UIScrollView
-
-extension UIScrollView {
-  /// The content offset at which this scroll view is scrolled to its top.
-  @nonobjc
-  fileprivate var topContentOffset: CGFloat {
-    -adjustedContentInset.top
-  }
-
-  /// The content offset at which this scroll view is scrolled to its bottom.
-  @nonobjc
-  fileprivate var bottomContentOffset: CGFloat {
-    max(contentSize.height - bounds.height + adjustedContentInset.bottom, topContentOffset)
-  }
 }


### PR DESCRIPTION
## Change summary
If any view in the hierarchy has a 3D transform, it's not valid to apply the insets as they may be incorrect; we should wait until there is no transform to so do.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
