### PR TITLE
Pass Initial Size To CollectionViewCell ContentView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - For top and bottom bars, if any view in the hierarchy has a scale transform, wait to apply the 
   insets as they may be incorrect.
-- Pass initial size to `CollectionViewCell` content view to better load embedded SwiftUI views.
+- Pass item initial size from `CollectionViewCell`'s content view to better load embedded 
+  SwiftUI views.
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - For top and bottom bars, if any view in the hierarchy has a scale transform, wait to apply the 
   insets as they may be incorrect.
+- Pass initial size to `CollectionViewCell` content view to better load embedded SwiftUI views.
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -13,11 +13,13 @@ public struct CollectionViewConfiguration {
   public init(
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
-    usesAccurateScrollToItem: Bool = true)
+    usesAccurateScrollToItem: Bool = true,
+    usesOptimisticCollectionViewCellItemSizing: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
+    self.usesOptimisticCollectionViewCellItemSizing = usesOptimisticCollectionViewCellItemSizing
   }
 
   // MARK: Public
@@ -67,4 +69,11 @@ public struct CollectionViewConfiguration {
   /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
 
+  /// When `true`, `CollectionViewCell` will give an embedded item its content view size before the initial Auto Layout layout
+  /// pass occurs. This is necessary to avoid an initial layout of embedded SwiftUI views with an incorrect size. After ensuring stability
+  /// this flag will be removed.
+  ///
+  /// Defaults to `true`.
+  ///
+  public var usesOptimisticCollectionViewCellItemSizing: Bool
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -49,6 +49,9 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     normalViewBackgroundColor = view.backgroundColor
 
     view.translatesAutoresizingMaskIntoConstraints = false
+    // Use the existing content view size so that we don't have to wait for auto layout to give this
+    // view an initial size.
+    view.bounds = contentView.bounds
     contentView.addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -51,7 +51,7 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     view.translatesAutoresizingMaskIntoConstraints = false
     // Use the existing content view size so that we don't have to wait for auto layout to give this
     // view an initial size.
-    view.bounds = contentView.bounds
+    view.frame = contentView.bounds
     contentView.addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),


### PR DESCRIPTION
## Change summary
- pass initial size to `CollectionViewCell`'s content view

## Background
- one of our Airbnb engineers noticed an issue where a SwiftUI view was laying out and loading images with an initial incorrect size, (72, 67) instead of the expected (320, 160)
- after tracing the code, I was seeing that an initial SwiftUI layout pass was occurring before the cell's content view received it's initial size

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
