### PR TITLE
Reading Initial Size Configuration Flag + CollectionViewReusableView Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - For top and bottom bars, if any view in the hierarchy has a scale transform, wait to apply the 
   insets as they may be incorrect.
-- Pass item initial size from `CollectionViewCell`'s content view to better load embedded 
-  SwiftUI views.
+- Pass initial size to embedded view from `CollectionViewCell`/`CollectionViewReusableView` to 
+  better load embedded SwiftUI views.
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -428,6 +428,7 @@ open class CollectionView: UICollectionView {
       cell.selectedBackgroundColor = selectionColor
     }
 
+    cell.usesOptimisticCollectionViewItemSizing = configuration.usesOptimisticCollectionViewItemSizing
     cell.accessibilityDelegate = self
 
     let metadata = ItemCellMetadata(
@@ -451,6 +452,7 @@ open class CollectionView: UICollectionView {
     with model: AnySupplementaryItemModel,
     animated: Bool)
   {
+    supplementaryView.usesOptimisticCollectionViewItemSizing = configuration.usesOptimisticCollectionViewItemSizing
     model.configure(
       reusableView: supplementaryView,
       traitCollection: traitCollection,

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -14,12 +14,12 @@ public struct CollectionViewConfiguration {
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
     usesAccurateScrollToItem: Bool = true,
-    usesOptimisticCollectionViewCellItemSizing: Bool = true)
+    usesOptimisticCollectionViewItemSizing: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
-    self.usesOptimisticCollectionViewCellItemSizing = usesOptimisticCollectionViewCellItemSizing
+    self.usesOptimisticCollectionViewItemSizing = usesOptimisticCollectionViewItemSizing
   }
 
   // MARK: Public
@@ -75,5 +75,5 @@ public struct CollectionViewConfiguration {
   ///
   /// Defaults to `true`.
   ///
-  public var usesOptimisticCollectionViewCellItemSizing: Bool
+  public var usesOptimisticCollectionViewItemSizing: Bool
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -49,9 +49,11 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     normalViewBackgroundColor = view.backgroundColor
 
     view.translatesAutoresizingMaskIntoConstraints = false
-    // Use the existing content view size so that we don't have to wait for auto layout to give this
-    // view an initial size.
-    view.frame = contentView.bounds
+    if usesOptimisticCollectionViewItemSizing {
+      // Use the existing content view size so that we don't have to wait for auto layout to give this
+      // view an initial size.
+      view.frame = contentView.bounds
+    }
     contentView.addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -131,6 +133,7 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
 
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
+  var usesOptimisticCollectionViewItemSizing: Bool = false
 
   // MARK: Private
 

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
@@ -28,6 +28,11 @@ public final class CollectionViewReusableView: UICollectionReusableView {
       return
     }
     view.translatesAutoresizingMaskIntoConstraints = false
+    if usesOptimisticCollectionViewItemSizing {
+      // Use the existing view size so that we don't have to wait for auto layout to give this
+      // wrapped view an initial size.
+      view.frame = bounds
+    }
     addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -65,4 +70,9 @@ public final class CollectionViewReusableView: UICollectionReusableView {
 
     return layoutAttributes
   }
+
+  // MARK: Internal
+
+  var usesOptimisticCollectionViewItemSizing: Bool = false
+
 }


### PR DESCRIPTION
## Change summary
- continuing this PR https://github.com/airbnb/epoxy-ios/pull/137
- applies same optimization to  `CollectionViewReusableView`
- reads configuration flag

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
