### PR TITLE
[EpoxyBars] Improve bar safe area logic

### DIFF
--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -191,10 +191,20 @@ extension InternalBarContainer {
 
   // Adjusts the additional safe area inset of the view controller based on the `insetBehavior`.
   func updateAdditionalSafeAreaInset(_ inset: CGFloat?) {
+    guard let viewController = viewController else { return }
+
     if let inset = inset {
-      viewController?.additionalSafeAreaInsets[keyPath: position.inset] = inset
+      // If any view in the hierarchy has a 3D transform, it's not valid to lessen the insets as
+      // they may be too short; we should wait until there is no transform to so do.
+      if hasHierarchyScaleTransform() {
+        if inset > viewController.additionalSafeAreaInsets[keyPath: position.inset] {
+          viewController.additionalSafeAreaInsets[keyPath: position.inset] = inset
+        }
+      } else {
+        viewController.additionalSafeAreaInsets[keyPath: position.inset] = inset
+      }
     } else if needsSafeAreaInsetReset {
-      viewController?.additionalSafeAreaInsets[keyPath: position.inset] = 0
+      viewController.additionalSafeAreaInsets[keyPath: position.inset] = 0
       needsSafeAreaInsetReset = false
     }
   }

--- a/Sources/EpoxyBars/BarInstaller/BarContainer.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarContainer.swift
@@ -190,13 +190,13 @@ extension InternalBarContainer {
   }
 
   // Adjusts the additional safe area inset of the view controller based on the `insetBehavior`.
-  func updateAdditionalSafeAreaInset(_ inset: CGFloat?) {
+  func updateAdditionalSafeAreaInset(_ inset: CGFloat?, hasHierarchyScaleTransform: Bool) {
     guard let viewController = viewController else { return }
 
     if let inset = inset {
       // If any view in the hierarchy has a 3D transform, it's not valid to lessen the insets as
       // they may be too short; we should wait until there is no transform to so do.
-      if hasHierarchyScaleTransform() {
+      if hasHierarchyScaleTransform {
         if inset > viewController.additionalSafeAreaInsets[keyPath: position.inset] {
           viewController.additionalSafeAreaInsets[keyPath: position.inset] = inset
         }
@@ -224,8 +224,16 @@ extension InternalBarContainer {
   }
 
   /// Sets the `layoutMargin` corresponding to the container's `position`
-  func setLayoutMargin(_ margin: CGFloat) {
-    layoutMargins[keyPath: position.inset] = insetMargins ? margin : 0
+  func setLayoutMargin(_ margin: CGFloat, hasHierarchyScaleTransform: Bool) {
+    // If any view in the hierarchy has a 3D transform, it's not valid to lessen the insets as
+    // they may be too short; we should wait until there is no transform to so do.
+    if hasHierarchyScaleTransform {
+      if margin > layoutMargins[keyPath: position.inset] {
+        layoutMargins[keyPath: position.inset] = insetMargins ? margin : 0
+      }
+    } else {
+      layoutMargins[keyPath: position.inset] = insetMargins ? margin : 0
+    }
   }
 
   // MARK: Private

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -160,10 +160,6 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
   /// Updates the view controller insets (either safe area or scroll view content inset) in response
   /// to the safe area, center, or bounds changing.
   private func updateInsets() {
-    // If any view in the hierarchy has a 3D transform, it's not valid to apply the insets as they
-    // may be incorrect; we should wait until there is no transform to so do.
-    guard !hasHierarchyScaleTransform() else { return }
-
     updateAdditionalSafeAreaInset(additionalSafeAreaInsetsBottom)
 
     // If offset from the bottom, use the original layout margins rather than the safe area margins,

--- a/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
+++ b/Sources/EpoxyBars/BottomBarInstaller/BottomBarContainer.swift
@@ -160,13 +160,17 @@ public final class BottomBarContainer: BarStackView, InternalBarContainer {
   /// Updates the view controller insets (either safe area or scroll view content inset) in response
   /// to the safe area, center, or bounds changing.
   private func updateInsets() {
-    updateAdditionalSafeAreaInset(additionalSafeAreaInsetsBottom)
+    let hasHierarchyScaleTransform = hasHierarchyScaleTransform()
+
+    updateAdditionalSafeAreaInset(
+      additionalSafeAreaInsetsBottom,
+      hasHierarchyScaleTransform: hasHierarchyScaleTransform)
 
     // If offset from the bottom, use the original layout margins rather than the safe area margins,
     // as the safe area no longer overlaps the bar.
     let margin = (bottomOffset > 0) ? 0 : viewController?.originalSafeAreaInsetBottom ?? 0
     updateScrollViewInset(allScrollViews, margin: margin)
-    setLayoutMargin(margin)
+    setLayoutMargin(margin, hasHierarchyScaleTransform: hasHierarchyScaleTransform)
   }
 
 }

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -191,10 +191,6 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
   ///
   /// Additionally keeps the scroll views pinned to their current offsets during the inset changes.
   private func updateInsets() {
-    // If any view in the hierarchy has a 3D transform, it's not valid to apply the insets as they
-    // may be incorrect; we should wait until there is no transform to so do.
-    guard !hasHierarchyScaleTransform() else { return }
-
     let scrollViewsAtEdge = scrollViewsAtEdge
 
     updateAdditionalSafeAreaInset(additionalSafeAreaInsetsTop)

--- a/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
+++ b/Sources/EpoxyBars/TopBarInstaller/TopBarContainer.swift
@@ -191,13 +191,17 @@ public final class TopBarContainer: BarStackView, InternalBarContainer {
   ///
   /// Additionally keeps the scroll views pinned to their current offsets during the inset changes.
   private func updateInsets() {
+    let hasHierarchyScaleTransform = hasHierarchyScaleTransform()
+
     let scrollViewsAtEdge = scrollViewsAtEdge
 
-    updateAdditionalSafeAreaInset(additionalSafeAreaInsetsTop)
+    updateAdditionalSafeAreaInset(
+      additionalSafeAreaInsetsTop,
+      hasHierarchyScaleTransform: hasHierarchyScaleTransform)
 
     let margin = layoutMarginsTop + extraLayoutMarginsTop
     updateScrollViewInset(allScrollViews, margin: margin)
-    setLayoutMargin(margin)
+    setLayoutMargin(margin, hasHierarchyScaleTransform: hasHierarchyScaleTransform)
 
     // Make sure to keep any scroll views at top/bottom when adjusting content/safe area insets.
     scrollToEdge(scrollViewsAtEdge)


### PR DESCRIPTION
## Change summary
We can improve this logic by avoiding applying the inset with a hierarchy scale when it is less than the current inset; this fixes issues where new view controllers that were added to a scaled view don't receive their initial insets.


## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*
- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
