### PR TITLE
Remove Optimistic Collection View Sizing Flag

### DIFF
--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -428,7 +428,6 @@ open class CollectionView: UICollectionView {
       cell.selectedBackgroundColor = selectionColor
     }
 
-    cell.usesOptimisticCollectionViewItemSizing = configuration.usesOptimisticCollectionViewItemSizing
     cell.accessibilityDelegate = self
 
     let metadata = ItemCellMetadata(
@@ -452,7 +451,6 @@ open class CollectionView: UICollectionView {
     with model: AnySupplementaryItemModel,
     animated: Bool)
   {
-    supplementaryView.usesOptimisticCollectionViewItemSizing = configuration.usesOptimisticCollectionViewItemSizing
     model.configure(
       reusableView: supplementaryView,
       traitCollection: traitCollection,

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -13,13 +13,11 @@ public struct CollectionViewConfiguration {
   public init(
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
-    usesAccurateScrollToItem: Bool = true,
-    usesOptimisticCollectionViewItemSizing: Bool = true)
+    usesAccurateScrollToItem: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
-    self.usesOptimisticCollectionViewItemSizing = usesOptimisticCollectionViewItemSizing
   }
 
   // MARK: Public
@@ -68,12 +66,4 @@ public struct CollectionViewConfiguration {
   ///
   /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
-
-  /// When `true`, `CollectionViewCell` will give an embedded item its content view size before the initial Auto Layout layout
-  /// pass occurs. This is necessary to avoid an initial layout of embedded SwiftUI views with an incorrect size. After ensuring stability
-  /// this flag will be removed.
-  ///
-  /// Defaults to `true`.
-  ///
-  public var usesOptimisticCollectionViewItemSizing: Bool
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -49,11 +49,9 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
     normalViewBackgroundColor = view.backgroundColor
 
     view.translatesAutoresizingMaskIntoConstraints = false
-    if usesOptimisticCollectionViewItemSizing {
-      // Use the existing content view size so that we don't have to wait for auto layout to give this
-      // view an initial size.
-      view.frame = contentView.bounds
-    }
+    // Use the existing content view size so that we don't have to wait for auto layout to give this
+    // view an initial size.
+    view.frame = contentView.bounds
     contentView.addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -133,7 +131,6 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
 
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
-  var usesOptimisticCollectionViewItemSizing = false
 
   // MARK: Private
 

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
@@ -28,11 +28,9 @@ public final class CollectionViewReusableView: UICollectionReusableView {
       return
     }
     view.translatesAutoresizingMaskIntoConstraints = false
-    if usesOptimisticCollectionViewItemSizing {
-      // Use the existing view size so that we don't have to wait for auto layout to give this
-      // wrapped view an initial size.
-      view.frame = bounds
-    }
+    // Use the existing view size so that we don't have to wait for auto layout to give this
+    // wrapped view an initial size.
+    view.frame = bounds
     addSubview(view)
     NSLayoutConstraint.activate([
       view.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -70,9 +68,5 @@ public final class CollectionViewReusableView: UICollectionReusableView {
 
     return layoutAttributes
   }
-
-  // MARK: Internal
-
-  var usesOptimisticCollectionViewItemSizing = false
 
 }


### PR DESCRIPTION
## Change summary
- this was already the default, but is no longer needed for testing

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
