### PR TITLE
Bump current version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.9.0...HEAD)
+## [Unreleased](https://github.com/airbnb/epoxy-ios/compare/0.10.0...HEAD)
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 
 ### Changed
 - Dropped support for Swift 5.4.

--- a/ConfigurePodspec.rb
+++ b/ConfigurePodspec.rb
@@ -3,7 +3,7 @@ def configure(spec:, name:, summary:, local_deps: [])
   # The shared CocoaPods version number for Epoxy.
   #
   # Change this constant to increment the Podspec version for all Epoxy Podspecs from a single place.
-  version = '0.9.0'
+  version = '0.10.0'
 
   spec.name = name
   spec.summary = summary


### PR DESCRIPTION
## Change summary

@thedrick suggested making a release of the current unreleased changes on master before merging the breaking changes in #143.

This PR bumps the current version as 0.10.0 and marks it as released today.
