### PR TITLE
Fix Incorrect Item/Cell FoundDuring WillDisplay and DidEndDisplaying Callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ...
 
 ### Fixed
-- ...
+- Fixed an issue causing incorrect view callbacks and a corresponding assertion when a view 
+  disappears during a collection view update and is only in the post-update data.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewData.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewData.swift
@@ -82,16 +82,6 @@ struct CollectionViewData {
     return section.items[indexPath.row].eraseToAnyItemModel()
   }
 
-  /// Returns the erased item model at the given index path, otherwise `nil` if it does not exist.
-  func itemIfPresent(at indexPath: IndexPath) -> AnyItemModel? {
-    guard indexPath.section < sections.count else { return nil }
-
-    let section = sections[indexPath.section]
-    guard indexPath.row < section.items.count else { return nil }
-
-    return section.items[indexPath.row].eraseToAnyItemModel()
-  }
-
   /// Returns the section model at the given index, asserting if it does not exist.
   func section(at index: Int) -> SectionModel? {
     guard index < sections.count else {

--- a/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/Internal/CollectionViewDataSource.swift
@@ -174,6 +174,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
   {
     guard
       let item = data?.item(at: indexPath),
+      let section = data?.section(at: indexPath.section),
       let reuseID = reuseIDStore.registeredReuseID(for: item.viewDifferentiator)
     else {
       // The `item(…)` or `registeredReuseID(…)` methods will assert in this scenario.
@@ -183,7 +184,11 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseID, for: indexPath)
 
     if let cell = cell as? CollectionViewCell {
-      self.collectionView?.configure(cell: cell, with: item, animated: false)
+      self.collectionView?.configure(
+        cell: cell,
+        with: item,
+        at: .init(itemDataID: item.dataID, section: .dataID(section.dataID)),
+        animated: false)
     } else {
       EpoxyLogger.shared.assertionFailure(
         "Only CollectionViewCell and subclasses are allowed in a CollectionView.")

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -132,6 +132,11 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
+  /// The item path of the cell from its last configuration update. Used to associate the view with the underlying data. When collection
+  /// view provides view display callbacks, if it is mid update, we need this to see if the view came from pre-update data or
+  /// post-update data.
+  var itemPath: ItemPath?
+
   // MARK: Private
 
   private var normalViewBackgroundColor: UIColor?

--- a/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
+++ b/Tests/EpoxyTests/CollectionViewTests/CollectionViewSpec.swift
@@ -1,11 +1,12 @@
 // Created by eric_horacek on 1/8/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-import EpoxyCollectionView
 import EpoxyCore
 import Nimble
 import Quick
 import UIKit
+
+@testable import EpoxyCollectionView
 
 // swiftlint:disable implicitly_unwrapped_optional
 
@@ -22,6 +23,14 @@ final class CollectionViewSpec: QuickSpec {
     required init?(coder _: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+  }
+
+  var mockCell: CollectionViewCell {
+    let cell = CollectionViewCell(frame: .zero)
+    cell.itemPath = .init(
+      itemDataID: DefaultDataID.noneProvided,
+      section: .dataID(DefaultDataID.noneProvided))
+    return cell
   }
 
   override func spec() {
@@ -85,7 +94,7 @@ final class CollectionViewSpec: QuickSpec {
           beforeEach {
             collectionView.delegate?.collectionView?(
               collectionView,
-              willDisplay: CollectionViewCell(),
+              willDisplay: self.mockCell,
               forItemAt: IndexPath(item: 0, section: 0))
           }
 
@@ -99,7 +108,7 @@ final class CollectionViewSpec: QuickSpec {
           beforeEach {
             collectionView.delegate?.collectionView?(
               collectionView,
-              didEndDisplaying: CollectionViewCell(),
+              didEndDisplaying: self.mockCell,
               forItemAt: IndexPath(item: 0, section: 0))
           }
 
@@ -220,7 +229,7 @@ final class CollectionViewSpec: QuickSpec {
             beforeEach {
               collectionView.delegate?.collectionView?(
                 collectionView,
-                willDisplay: CollectionViewCell(),
+                willDisplay: self.mockCell,
                 forItemAt: IndexPath(item: 0, section: 0))
             }
 
@@ -236,7 +245,7 @@ final class CollectionViewSpec: QuickSpec {
               beforeEach {
                 collectionView.delegate?.collectionView?(
                   collectionView,
-                  didEndDisplaying: CollectionViewCell(),
+                  didEndDisplaying: self.mockCell,
                   forItemAt: IndexPath(item: 0, section: 0))
               }
 
@@ -248,7 +257,7 @@ final class CollectionViewSpec: QuickSpec {
                 beforeEach {
                   collectionView.delegate?.collectionView?(
                     collectionView,
-                    willDisplay: CollectionViewCell(),
+                    willDisplay: self.mockCell,
                     forItemAt: IndexPath(item: 0, section: 0))
                 }
 
@@ -279,7 +288,7 @@ final class CollectionViewSpec: QuickSpec {
                 beforeEach {
                   collectionView.delegate?.collectionView?(
                     collectionView,
-                    didEndDisplaying: CollectionViewCell(),
+                    didEndDisplaying: self.mockCell,
                     forItemAt: IndexPath(item: 0, section: 0))
                   collectionView.delegate?.collectionView?(
                     collectionView,


### PR DESCRIPTION
## Change summary
- fixes an issue discovered in the Airbnb app where while during a collection view update, the collection view will provide a didEndDisplay item callback for a cell that is only in the new data, this would cause a runtime assertion and incorrect view callbacks from being propagated

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [x] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
