### PR TITLE
Removed unused accessibility delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed an issue causing incorrect view callbacks and a corresponding assertion when a view 
   disappears during a collection view update and is only in the post-update data.
+- Removed non-functioning `accessibilityDelegate` and associated code.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -288,15 +288,6 @@ open class CollectionView: UICollectionView {
     UIAccessibility.post(notification: notification, argument: cell)
   }
 
-  /// Moves accessibility focus to item that was most previously focused.
-  ///
-  /// The item view must be visible at the time this method is called, else this method will have
-  /// no effect.
-  public func moveAccessibilityFocusToLastFocusedElement() {
-    guard let lastFocusedDataID = lastFocusedDataID else { return }
-    moveAccessibilityFocusToItem(at: lastFocusedDataID)
-  }
-
   public func selectItem(at path: ItemPath, animated: Bool) {
     guard let indexPath = indexPathForItem(at: path) else {
       EpoxyLogger.shared.assertionFailure("item not found")
@@ -438,7 +429,6 @@ open class CollectionView: UICollectionView {
       cell.selectedBackgroundColor = selectionColor
     }
 
-    cell.accessibilityDelegate = self
     cell.itemPath = itemPath
 
     let metadata = ItemCellMetadata(
@@ -518,7 +508,6 @@ open class CollectionView: UICollectionView {
 
   private var updateState = UpdateState.notUpdating
   private var ephemeralStateCache = [AnyHashable: Any?]()
-  private var lastFocusedDataID: ItemPath?
 
   /// A dictionary used to track visible sections, keyed by `SectionModel.dataID` and with a value
   /// of the `Set` of visible items in that section, else an empty `Set` or `nil` if there are none.
@@ -1156,32 +1145,6 @@ extension CollectionView: CollectionViewDataSourceReorderingDelegate {
         inSection: sourceSection,
         toDestinationItem: destinationItem,
         inSection: destinationSection)
-  }
-}
-
-// MARK: CollectionViewCellAccessibilityDelegate
-
-extension CollectionView: CollectionViewCellAccessibilityDelegate {
-  func collectionViewCellDidBecomeFocused(cell: CollectionViewCell) {
-    guard let (item, section) = itemAndSectionModel(for: cell) else { return }
-
-    lastFocusedDataID = .init(itemDataID: item.dataID, section: .dataID(section.dataID))
-
-    accessibilityDelegate?.collectionView(
-      self,
-      itemDidBecomeFocused: item,
-      with: cell.view,
-      in: section)
-  }
-
-  func collectionViewCellDidLoseFocus(cell: CollectionViewCell) {
-    guard let (item, section) = itemAndSectionModel(for: cell) else { return }
-
-    accessibilityDelegate?.collectionView(
-      self,
-      itemDidLoseFocus: item,
-      with: cell.view,
-      in: section)
   }
 }
 

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -129,7 +129,6 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
 
   // MARK: Internal
 
-  weak var accessibilityDelegate: CollectionViewCellAccessibilityDelegate?
   var ephemeralViewCachedStateProvider: ((Any?) -> Void)?
 
   /// The item path of the cell from its last configuration update. Used to associate the view with the underlying data. When collection
@@ -175,15 +174,5 @@ extension CollectionViewCell {
       return super.accessibilityElementsHidden
     }
     set { super.accessibilityElementsHidden = newValue }
-  }
-
-  public override func accessibilityElementDidBecomeFocused() {
-    super.accessibilityElementDidBecomeFocused()
-    accessibilityDelegate?.collectionViewCellDidBecomeFocused(cell: self)
-  }
-
-  public override func accessibilityElementDidLoseFocus() {
-    super.accessibilityElementDidLoseFocus()
-    accessibilityDelegate?.collectionViewCellDidLoseFocus(cell: self)
   }
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/Internal/CollectionViewCellAccessibilityDelegate.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/Internal/CollectionViewCellAccessibilityDelegate.swift
@@ -1,7 +1,0 @@
-// Created by nick_miller on 7/15/19.
-// Copyright © 2019 Airbnb Inc. All rights reserved.
-
-protocol CollectionViewCellAccessibilityDelegate: AnyObject {
-  func collectionViewCellDidBecomeFocused(cell: CollectionViewCell)
-  func collectionViewCellDidLoseFocus(cell: CollectionViewCell)
-}


### PR DESCRIPTION
## Change summary
- noticed this code can now be remove since it only worked for UITableView

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
