### PR TITLE
Fix CollectionViewVisibilityMetadata Assertions and Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue causing incorrect view callbacks and a corresponding assertion when a view 
   disappears during a collection view update and is only in the post-update data.
 - Removed non-functioning `accessibilityDelegate` and associated code.
+- Fixed a possible index out of bounds assertion when accessing `visibilityMetadata` during a 
+  batch update.
+- Added caching for `visibilityMetadata` calculations.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -168,7 +168,7 @@ open class CollectionView: UICollectionView {
     // `scrollViewDidScroll` callback
     if
       let (indexPaths, visibilityMetadata) = cachedVisibilityMetadataForVisibleIndexPaths,
-        indexPaths == visibleItems
+      indexPaths == visibleItems
     {
       return visibilityMetadata
     }


### PR DESCRIPTION
## Change summary
- Uses the new functions [added here ](https://github.com/airbnb/epoxy-ios/pull/146)to avoid assertions when accessing visibility metadata during a batch update
- Added caching

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
