### PR TITLE
[SwiftUI] Fix reused UIHostingController sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch update.
 - Added caching for `visibilityMetadata` calculations.
 - Fixed an issue that could cause SwiftUI views to be incorrectly sized in a collection view.
+- Fixed an issue that could cause collection view cells to layout with unexpected dimensions
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
@@ -13,7 +13,8 @@ extension View {
   ///   - reuseBehavior: The reuse behavior of the `EpoxySwiftUIHostingView`.
   public func itemModel(
     dataID: AnyHashable,
-    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable)
+    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable,
+    usesPublicLayoutApisForSwiftUIHostingControllers: Bool = false)
     -> ItemModel<EpoxySwiftUIHostingView<Self>>
   {
     EpoxySwiftUIHostingView<Self>.itemModel(
@@ -21,7 +22,8 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
-        initialContent: .init(rootView: self, dataID: dataID)))
+        initialContent: .init(rootView: self, dataID: dataID),
+        usesPublicLayoutApisForSwiftUIHostingControllers: usesPublicLayoutApisForSwiftUIHostingControllers))
       .linkDisplayLifecycle()
   }
 }


### PR DESCRIPTION
## Change summary

There was an issue we were running in with epoxy in swiftUI where the size of images would not be sized properly that were hosted within the `SwiftUIHostingController`. This seemed to point to a usage in the internal `._render` function. Since this is a private api we can't modify anything with it, I investigated for alternatives.  It seems invoking a layout on the view prevents the issue and it doesn't break the example project for swiftUI in epoxy. This private api was originally introduce in this [pr](https://github.com/airbnb/epoxy-ios/pull/77) so I had removed the code related to that function.

In the airbnb app this case was related to swift UI cards inside of our UIKit carousel which relied on the swiftUI hosting view. 
These images are noticeably lower resolution before compared to after. In proxyman I saw that we were fetching 240 px width images before with `._render` and after with layout the 480 px width images
| Before with ._render | After without ._render and using view layout methods |
| -------------------- | ---------------------- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-09-19 at 12 01 25](https://github.com/airbnb/epoxy-ios/assets/4534318/d131ab0b-4935-457b-b892-8298fb434240)  | ![Simulator Screenshot - iPhone 14 Pro - 2023-09-19 at 11 58 02](https://github.com/airbnb/epoxy-ios/assets/4534318/d7f73dc7-8064-4071-afad-be40f989dc53) | 


## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

Tested using the epoxy example project for swiftUI in epoxy and saw that the cell was sized properly and that smaller sizes would not resize to have the bigger cells height. You can see in the no render or view layout case that we'd have mis-sized cells. 

| Before | with no render or view layout | With view layout |
| ------ | ----------------- | ---------- |
| ![control](https://github.com/airbnb/epoxy-ios/assets/4534318/9ee0fcac-f39f-4a05-a42e-f77ec208fbf8) | ![no render](https://github.com/airbnb/epoxy-ios/assets/4534318/e4841c81-1eb2-47b9-9a03-c0e683bdc634) | ![test](https://github.com/airbnb/epoxy-ios/assets/4534318/92115b22-581e-4772-91aa-881108b3c799) | 

Also checked in app as described in summary and seemed to resolve the issue


## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
