### PR TITLE
[SwiftUI] Adds forcesEarlySwiftUIRendering flag to fix SwiftUI Cell Sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch update.
 - Added caching for `visibilityMetadata` calculations.
 - Fixed an issue that could cause SwiftUI views to be incorrectly sized in a collection view.
-- Fixed an issue that could cause collection view cells to layout with unexpected dimensions
+- Added `forcesEarlySwiftUIRendering` flag to `CollectionViewConfiguration` to test a SwiftUI layout
+  approach to resolve an issue that could cause collection view cells to layout with 
+  unexpected dimensions
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch update.
 - Added caching for `visibilityMetadata` calculations.
 - Fixed an issue that could cause SwiftUI views to be incorrectly sized in a collection view.
+- Fixed an issue that could cause collection view cells to layout with unexpected dimensions
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -445,6 +445,7 @@ open class CollectionView: UICollectionView {
     }
 
     cell.itemPath = itemPath
+    cell.forcesEarlySwiftUIRendering = configuration.forcesEarlySwiftUIRendering
 
     let metadata = ItemCellMetadata(
       traitCollection: traitCollection,
@@ -469,6 +470,7 @@ open class CollectionView: UICollectionView {
     animated: Bool)
   {
     supplementaryView.itemPath = itemPath
+    supplementaryView.forcesEarlySwiftUIRendering = configuration.forcesEarlySwiftUIRendering
     model.configure(
       reusableView: supplementaryView,
       traitCollection: traitCollection,

--- a/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionViewConfiguration.swift
@@ -13,11 +13,13 @@ public struct CollectionViewConfiguration {
   public init(
     usesBatchUpdatesForAllReloads: Bool = true,
     usesCellPrefetching: Bool = true,
-    usesAccurateScrollToItem: Bool = true)
+    usesAccurateScrollToItem: Bool = true,
+    forcesEarlySwiftUIRendering: Bool = true)
   {
     self.usesBatchUpdatesForAllReloads = usesBatchUpdatesForAllReloads
     self.usesCellPrefetching = usesCellPrefetching
     self.usesAccurateScrollToItem = usesAccurateScrollToItem
+    self.forcesEarlySwiftUIRendering = forcesEarlySwiftUIRendering
   }
 
   // MARK: Public
@@ -66,4 +68,10 @@ public struct CollectionViewConfiguration {
   ///
   /// - SeeAlso: `CollectionViewScrollToItemHelper`
   public var usesAccurateScrollToItem: Bool
+
+  /// Flag to use a semi-private API to force an early render of a SwiftUI view embedded in a `UIHostingController`. This is used
+  /// to synchronously resize after updating the `rootView`. When disabled, layout is forced using standard UIKit functions, a newer
+  /// approach which is being tested for viability and to resolve issues where SwiftUI views in collection view cells undergo a layout pass
+  /// with unexpected dimensions.
+  public var forcesEarlySwiftUIRendering: Bool
 }

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewCell.swift
@@ -7,7 +7,7 @@ import UIKit
 // MARK: - CollectionViewCell
 
 /// An internal cell class for use in a `CollectionView`.
-public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
+public final class CollectionViewCell: UICollectionViewCell, ItemCellView, SwiftUIRenderingConfigurable {
 
   // MARK: Lifecycle
 
@@ -26,6 +26,13 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
   public private(set) var view: UIView?
 
   public var selectedBackgroundColor: UIColor?
+
+  /// See `CollectionViewConfiguration.forcesEarlySwiftUIRendering` for an explanation of this behavior.
+  public var forcesEarlySwiftUIRendering = true {
+    didSet {
+      updateForcesEarlySwiftUIRendering()
+    }
+  }
 
   override public var isSelected: Bool {
     didSet {
@@ -59,6 +66,8 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
       view.topAnchor.constraint(equalTo: contentView.topAnchor),
       view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
     ])
+
+    updateForcesEarlySwiftUIRendering()
   }
 
   override public func preferredLayoutAttributesFitting(
@@ -149,6 +158,12 @@ public final class CollectionViewCell: UICollectionViewCell, ItemCellView {
       view?.backgroundColor = selectedBackgroundColor
     } else {
       view?.backgroundColor = normalViewBackgroundColor
+    }
+  }
+
+  private func updateForcesEarlySwiftUIRendering() {
+    if let configurableView = view as? SwiftUIRenderingConfigurable {
+      configurableView.forcesEarlySwiftUIRendering = forcesEarlySwiftUIRendering
     }
   }
 

--- a/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/ReusableViews/CollectionViewReusableView.swift
@@ -1,10 +1,11 @@
 //  Created by Laura Skelton on 9/8/17.
 //  Copyright © 2017 Airbnb. All rights reserved.
 
+import EpoxyCore
 import UIKit
 
 /// An internal collection reusable view class for use in a `CollectionView`.
-public final class CollectionViewReusableView: UICollectionReusableView {
+public final class CollectionViewReusableView: UICollectionReusableView, SwiftUIRenderingConfigurable {
 
   // MARK: Lifecycle
 
@@ -21,6 +22,13 @@ public final class CollectionViewReusableView: UICollectionReusableView {
   // MARK: Public
 
   public private(set) var view: UIView?
+
+  /// See `CollectionViewConfiguration.forcesEarlySwiftUIRendering` for an explanation of this behavior.
+  public var forcesEarlySwiftUIRendering = false {
+    didSet {
+      updateForcesEarlySwiftUIRendering()
+    }
+  }
 
   /// Pass a view for this view's element kind and reuseID that the view will pin to its edges.
   public func setViewIfNeeded(view: UIView) {
@@ -39,6 +47,8 @@ public final class CollectionViewReusableView: UICollectionReusableView {
       view.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
     self.view = view
+
+    updateForcesEarlySwiftUIRendering()
   }
 
   override public func preferredLayoutAttributesFitting(
@@ -75,5 +85,13 @@ public final class CollectionViewReusableView: UICollectionReusableView {
   /// view provides view display callbacks, if it is mid update, we need this to see if the view came from pre-update data or
   /// post-update data.
   var itemPath: SupplementaryItemPath?
+
+  // MARK: Private
+
+  private func updateForcesEarlySwiftUIRendering() {
+    if let configurableView = view as? SwiftUIRenderingConfigurable {
+      configurableView.forcesEarlySwiftUIRendering = forcesEarlySwiftUIRendering
+    }
+  }
 
 }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
@@ -13,8 +13,7 @@ extension View {
   ///   - reuseBehavior: The reuse behavior of the `EpoxySwiftUIHostingView`.
   public func itemModel(
     dataID: AnyHashable,
-    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable,
-    usesPublicLayoutApisForSwiftUIHostingControllers: Bool = false)
+    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable)
     -> ItemModel<EpoxySwiftUIHostingView<Self>>
   {
     EpoxySwiftUIHostingView<Self>.itemModel(
@@ -22,8 +21,7 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
-        initialContent: .init(rootView: self, dataID: dataID),
-        usesPublicLayoutApisForSwiftUIHostingControllers: usesPublicLayoutApisForSwiftUIHostingControllers))
+        initialContent: .init(rootView: self, dataID: dataID)))
       .linkDisplayLifecycle()
   }
 }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
@@ -13,7 +13,8 @@ extension View {
   ///   - reuseBehavior: The reuse behavior of the `EpoxySwiftUIHostingView`.
   public func itemModel(
     dataID: AnyHashable,
-    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable)
+    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable,
+    usesPublicLayoutApisForSwiftUIHostingControllers: Bool = false)
     -> ItemModel<EpoxySwiftUIHostingView<Self>>
   {
     EpoxySwiftUIHostingView<Self>.itemModel(
@@ -21,7 +22,8 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
-        initialContent: .init(rootView: self, dataID: dataID)))
+        initialContent: .init(rootView: self, dataID: dataID),
+        usesPublicLayoutApisForSwiftUIHostingControllers: usesPublicLayoutApisForSwiftUIHostingControllers))
       .linkDisplayLifecycle()
   }
 }


### PR DESCRIPTION
## Change summary
- an updated version of this PR using a collection view configuration flag https://github.com/airbnb/epoxy-ios/pull/152

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
