### PR TITLE
Making AnyItemModel implement ErasedContentProviding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `configuredView(traitCollection:)` API to `SupplementaryItemModeling`
 - Changed `NavigationModel`'s `remove()` method access modifier to public (previously internal).
 - Changed `NavigationModel`'s `handleDidRemove()` method access modifier to public (previously internal).
+- Changed `AnyItemModel` to implement the `ErasedContentProviding` protocol.
+- Changed `ErasedContentProviding` protocol to use its type name instead of `Self` in the keys of its `EpoxyModelProperty` properties `contentProperty` and `isContentEqualProperty `.
 
 ## [0.9.0](https://github.com/airbnb/epoxy-ios/compare/0.8.0...0.9.0) - 2022-10-25
 

--- a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
@@ -33,6 +33,10 @@ public struct AnyItemModel: EpoxyModeled {
 
 }
 
+// MARK: ErasedContentProviding
+
+extension AnyItemModel: ErasedContentProviding {}
+
 // MARK: WillDisplayProviding
 
 extension AnyItemModel: WillDisplayProviding { }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift
@@ -35,7 +35,7 @@ public struct AnyItemModel: EpoxyModeled {
 
 // MARK: ErasedContentProviding
 
-extension AnyItemModel: ErasedContentProviding {}
+extension AnyItemModel: ErasedContentProviding { }
 
 // MARK: WillDisplayProviding
 

--- a/Sources/EpoxyCore/Model/Providers/ErasedContentProviding.swift
+++ b/Sources/EpoxyCore/Model/Providers/ErasedContentProviding.swift
@@ -14,7 +14,7 @@ public protocol ErasedContentProviding {
   /// A closure that can be called to determine whether the given `model`'s `erasedContent` is equal
   /// to this model's `erasedContent`, else `nil` if there is no content or the content is always
   /// equal.
-  var isErasedContentEqual: ((Self) -> Bool)? { get }
+  var isErasedContentEqual: ((ErasedContentProviding) -> Bool)? { get }
 }
 
 // MARK: - EpoxyModeled
@@ -32,7 +32,7 @@ extension EpoxyModeled where Self: ErasedContentProviding {
   /// A closure that can be called to determine whether the given `model`'s `erasedContent` is equal
   /// to this model's `erasedContent`, else `nil` if there is no content or the content is always
   /// equal.
-  public var isErasedContentEqual: ((Self) -> Bool)? {
+  public var isErasedContentEqual: ((ErasedContentProviding) -> Bool)? {
     get { self[isContentEqualProperty] }
     set { self[isContentEqualProperty] = newValue }
   }
@@ -40,10 +40,10 @@ extension EpoxyModeled where Self: ErasedContentProviding {
   // MARK: Private
 
   private var contentProperty: EpoxyModelProperty<Any?> {
-    .init(keyPath: \Self.erasedContent, defaultValue: nil, updateStrategy: .replace)
+    .init(keyPath: \ErasedContentProviding.erasedContent, defaultValue: nil, updateStrategy: .replace)
   }
 
-  private var isContentEqualProperty: EpoxyModelProperty<((Self) -> Bool)?> {
-    .init(keyPath: \Self.isErasedContentEqual, defaultValue: nil, updateStrategy: .replace)
+  private var isContentEqualProperty: EpoxyModelProperty<((ErasedContentProviding) -> Bool)?> {
+    .init(keyPath: \ErasedContentProviding.isErasedContentEqual, defaultValue: nil, updateStrategy: .replace)
   }
 }


### PR DESCRIPTION
## Change summary

This PR changes `AnyItemModel` to implement the `ErasedContentProviding` protocol.

It also changes the `ErasedcontentProviding` protocol to use its type name instead of `Self` in the keys of its `EpoxyModelProperty` properties `contentProperty` and `isContentEqualProperty `.

## Context

We found this gap through a test failure that wasn't able to find a SwiftUI View used to build items of a `SectionModel`.
The reason for that is that these SwiftUI Views were placed in the `SectionModel` as `AnyItemModel` instances created from the call to `eraseToAnyItemModel()` method in the `ItemModeling` protocol:

```swift
extension AnyItemModel: ItemModeling {
  public func eraseToAnyItemModel() -> AnyItemModel { self }
}
```

Our test framework has an implementation similar to the snippet below to find SwiftUI Views.
The commented (labeled "TODO: Support AnyItemModel") code below is what would need to be added to support these type erased item models that contain SwiftUI Views. 

```swift
  /// - Note: The underlying model must conform to `EpoxyCore.ErasedContentProviding` for a SwiftUI `View` to
  /// be found.
  public func swiftUIView<T: View>(of _: T.Type) -> T? {
    let erasedContentProviding = {

//      TODO: Support AnyItemModel
//      if let anyItemModel = model as? AnyItemModel {
//        return anyItemModel.model as? (any ErasedContentProviding)
//      }

      return model as? (any ErasedContentProviding)
    }()

    let content = erasedContentProviding?.erasedContent as? EpoxySwiftUIHostingView<T>.Content
    return content?.rootView
  }
}
```

That additional commented code would be needed since `AnyItemModel` did not implement `ErasedContentProviding` but as a type eraser, wrapped a model that did.

We then concluded that all we would need is to make `AnyItemModel` implement `ErasedContentProviding` and the issue would be resolved. But the SwiftUI View still wasn't found in the test as the `contentProperty` was always `nil`.

**So, we asked ourselves:** 
But doesn't `AnyItemModel` provide a passthrough [storage property](https://github.com/airbnb/epoxy-ios/blob/eeb182b6afc7ddabda25e18cf5d163c66a33917a/Sources/EpoxyCollectionView/Models/ItemModel/AnyItemModel.swift#L27-L32) to its backing model property when called directly? (snippet below)

```swift
public struct AnyItemModel: EpoxyModeled {
  ... 
  public var model: InternalItemModeling

  /// Implemented as a passthrough to the backing model's storage to allow custom model properties
  /// to be accessed and modified through this type eraser.
  public var storage: EpoxyModelStorage {
    get { model.storage }
    set { model.storage = newValue }
  }
  ...
}
```

That's where changing the `EpoxyModelProperty` keys from `Self` to `ErasedContentProviding` comes in:

Storing the keys with `Self` would always resolve to the type name that implements `ErasedContentProviding`.
That means when the backing model storage was created, it would have the key path as something like `KeyPath<EpoxyCollectionView.ItemModel<SwiftUIViewName>>`.

When the test tried to retrieve that same property from the storage of type `EpoxyModelStorage` using its [subscript getter](https://github.com/airbnb/epoxy-ios/blob/eeb182b6afc7ddabda25e18cf5d163c66a33917a/Sources/EpoxyCore/Model/EpoxyModelStorage.swift#L20-L30), the key passed would be `KeyPath<EpoxyCollectionView.AnyItemModel>`.

As the keys mismatched, the return was always the default value (`nil` in this case) and the SwiftUI View was never found from the test query.

Using `ErasedContentProviding` instead of `Self` ensures that key path will be always consistent for the property on both the creation and retrieval times. They key will be something like `KeyPath<EpoxyCore.ErasedContentProviding>`.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device
- [x] Ran test module of our private code that finds the SwiftUI View in an Epoxy Section Model.

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
