### PR TITLE
Pin hosting controller to the top of the layout margin guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approach to resolve an issue that could cause collection view cells to layout with 
   unexpected dimensions
 - Made new layout-based SwiftUI cell rendering option the default.
+- Pin `EpoxySwiftUIHostingView` content to `layoutMarginsGuide` to ensure content respects the safe area
+  when installed in a `TopBarContainer` or `BottomBarContainer`.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -343,9 +343,13 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the top safe area
+      // when installed inside a `TopBarContainer`
       viewController.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
       viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-      viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the bottom safe area
+      // when installed inside a `BottomBarContainer`
+      viewController.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
     ])
 
     viewController.didMove(toParent: parent)

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -343,7 +343,7 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-      viewController.view.topAnchor.constraint(equalTo: topAnchor),
+      viewController.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
       viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
       viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])


### PR DESCRIPTION
Pin hosting controller to the top of the layout margin guide to ensure that a SwiftUI View used as `BarModel` is rendered below the top or bottom edge of the safe area.

|Before|After|
|---|---|
|![image (4)](https://github.com/airbnb/epoxy-ios/assets/20710815/678c2066-278c-45c4-8a0f-43380ca7209d)|![image (5)](https://github.com/airbnb/epoxy-ios/assets/20710815/49cca7ed-a6e9-4b35-be13-60ec7324d119)|

## Change summary

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
