### PR TITLE
Revert "Pin hosting controller to the top of the layout margin guide"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approach to resolve an issue that could cause collection view cells to layout with 
   unexpected dimensions
 - Made new layout-based SwiftUI cell rendering option the default.
-- Pin `EpoxySwiftUIHostingView` content to `layoutMarginsGuide` to ensure content respects the safe area
-  when installed in a `TopBarContainer` or `BottomBarContainer`.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -343,13 +343,9 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the top safe area
-      // when installed inside a `TopBarContainer`
-      viewController.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      viewController.view.topAnchor.constraint(equalTo: topAnchor),
       viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the bottom safe area
-      // when installed inside a `BottomBarContainer`
-      viewController.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+      viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
 
     viewController.didMove(toParent: parent)


### PR DESCRIPTION
Reverts airbnb/epoxy-ios#157