### PR TITLE
Fix EpoxySwiftUIHostingView updates safe area insets

### DIFF
--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -87,6 +87,7 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
       }
     })
     layoutMargins = .zero
+    insetsLayoutMarginsFromSafeArea = false
   }
 
   @available(*, unavailable)


### PR DESCRIPTION
## Change summary

Fixes an issue where the hosting view updates its safe area insets while being using inside a scrollview causing a broken layout

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
