### PR TITLE
[iOS] Revert epoxy hosting view margin changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approach to resolve an issue that could cause collection view cells to layout with 
   unexpected dimensions
 - Made new layout-based SwiftUI cell rendering option the default.
-- Pin `EpoxySwiftUIHostingView` content to `layoutMarginsGuide` to ensure content respects the safe area
-  when installed in a `TopBarContainer` or `BottomBarContainer`.
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -87,7 +87,6 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
       }
     })
     layoutMargins = .zero
-    insetsLayoutMarginsFromSafeArea = false
   }
 
   @available(*, unavailable)
@@ -346,11 +345,11 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
       viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
       // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the top safe area
       // when installed inside a `TopBarContainer`
-      viewController.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      viewController.view.topAnchor.constraint(equalTo: topAnchor),
       viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
       // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the bottom safe area
       // when installed inside a `BottomBarContainer`
-      viewController.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+      viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
 
     viewController.didMove(toParent: parent)


### PR DESCRIPTION
## Change summary

Revert https://github.com/airbnb/epoxy-ios/pull/157 and https://github.com/airbnb/epoxy-ios/pull/159

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [ ] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
