### PR TITLE
Revert "Expose configuration to ignore EpoxySwiftUIHostingController safe area"

### DIFF
--- a/Sources/EpoxyBars/BarModel/SwiftUI.View+BarModel.swift
+++ b/Sources/EpoxyBars/BarModel/SwiftUI.View+BarModel.swift
@@ -11,12 +11,9 @@ extension View {
   ///   - dataID: An ID that uniquely identifies this item relative to other items in the
   ///     same collection.
   ///   - reuseBehavior: The reuse behavior of the `EpoxySwiftUIHostingView`.
-  ///   - ignoreSafeArea: Whether or not the underlying `EpoxySwiftUIHostingController` will ignore its safe area.
-  ///     Only set this to `false` when installing this BarModel using `BarContainerInsetBehavior.barHeightContentInset` or `BarContainerInsetBehavior.none`.
   public func barModel(
     dataID: AnyHashable? = nil,
-    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable,
-    ignoreSafeArea: Bool = true)
+    reuseBehavior: SwiftUIHostingViewReuseBehavior = .reusable)
     -> BarModel<EpoxySwiftUIHostingView<Self>>
   {
     EpoxySwiftUIHostingView<Self>.barModel(
@@ -24,8 +21,7 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
-        initialContent: .init(rootView: self, dataID: dataID),
-        ignoreSafeArea: ignoreSafeArea))
+        initialContent: .init(rootView: self, dataID: dataID)))
       .linkDisplayLifecycle()
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -67,7 +67,7 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     epoxyContent = EpoxyHostingContent(rootView: style.initialContent.rootView)
     viewController = EpoxySwiftUIHostingController(
       rootView: .init(content: epoxyContent, environment: epoxyEnvironment),
-      ignoreSafeArea: style.ignoreSafeArea)
+      ignoreSafeArea: true)
 
     dataID = style.initialContent.dataID ?? DefaultDataID.noneProvided as AnyHashable
 
@@ -97,24 +97,13 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
   // MARK: Public
 
   public struct Style: Hashable {
-
-    // MARK: Lifecycle
-
-    public init(
-      reuseBehavior: SwiftUIHostingViewReuseBehavior,
-      initialContent: Content,
-      ignoreSafeArea: Bool = true)
-    {
+    public init(reuseBehavior: SwiftUIHostingViewReuseBehavior, initialContent: Content) {
       self.reuseBehavior = reuseBehavior
       self.initialContent = initialContent
-      self.ignoreSafeArea = ignoreSafeArea
     }
-
-    // MARK: Public
 
     public var reuseBehavior: SwiftUIHostingViewReuseBehavior
     public var initialContent: Content
-    public var ignoreSafeArea: Bool
 
     public static func == (lhs: Style, rhs: Style) -> Bool {
       lhs.reuseBehavior == rhs.reuseBehavior

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -343,12 +343,8 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the top safe area
-      // when installed inside a `TopBarContainer`
       viewController.view.topAnchor.constraint(equalTo: topAnchor),
       viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-      // Pining the hosting view controller to layoutMarginsGuide ensures the content respects the bottom safe area
-      // when installed inside a `BottomBarContainer`
       viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
 


### PR DESCRIPTION
This reverts airbnb/epoxy-ios#161, which is not needed thanks to the existence of the `epoxyLayoutMargins` modifier.

```swift
// MARK: - View

extension View {
  /// Applies the layout margins from the parent `EpoxySwiftUIHostingView` to this `View`, if there
  /// are any.
  ///
  /// Can be used to have a background in SwiftUI underlap the safe area within a bar installer, for
  /// example.
  ///
  /// These margins are propagated via the `EnvironmentValues.epoxyLayoutMargins`.
  public func epoxyLayoutMargins() -> some View {
    modifier(EpoxyLayoutMarginsPadding())
  }
}
```

We can go back to always forcing `EpoxySwiftUIHostingView` to ignore safe area insets. Anyone who wants a bar to go into the safe area region can do so using `epoxyLayoutMargins`.

Note: We can't apply `epoxyLayoutMargins` automatically for bars because the exact position that the padding is inserted is view-specific. For example, people probably want to use the `epoxyLayoutMargins` modifier _before_ a `background` modifier.