### PR TITLE
Fix visionOS SwiftUI bar interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approach to resolve an issue that could cause collection view cells to layout with 
   unexpected dimensions
 - Made new layout-based SwiftUI cell rendering option the default.
+- Fixed interaction of SwiftUI bars on visionOS
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyBars/BarInstaller/BarStackView.swift
+++ b/Sources/EpoxyBars/BarInstaller/BarStackView.swift
@@ -295,7 +295,10 @@ public class BarStackView: UIStackView, EpoxyableView {
     for (index, wrapper) in zOrderedWrappers.enumerated() {
       // We pick 1000 as a sensible max to decrement from since we would never have that may bars.
       // We don't decrement from 0 since that causes bars to be invisible for some reason.
-      wrapper.layer.zPosition = CGFloat(1000 - index)
+      // Due to a bug on visionOS, we need to clamp this to be between -1 and 1, otherwise
+      // interaction breaks for SwiftUI views.
+      // http://openradar.appspot.com/radar?id=5534724382523392
+      wrapper.layer.zPosition = CGFloat(1000 - index) / 1000
       wrapper.zOrder = zOrder
     }
   }


### PR DESCRIPTION
## Change summary
This works around a visionOS bug that causes SwiftUI views contained in hosting controllers to have broken interaction if their `zPosition`'s magnitude is too large. A safe workaround is to ensure that `zPosition` is always between -1 and 1, which provides ample precision for all of our needs.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
