### PR TITLE
Fix timing of layout margin layout invalidation for bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unexpected dimensions
 - Made new layout-based SwiftUI cell rendering option the default.
 - Fixed interaction of SwiftUI bars on visionOS
+- Added flag for forcing layout on a hosted SwiftUI view after layout margins change
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Sources/EpoxyBars/BarModel/SwiftUI.View+BarModel.swift
+++ b/Sources/EpoxyBars/BarModel/SwiftUI.View+BarModel.swift
@@ -21,6 +21,7 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
+        forceLayoutOnLayoutMarginsChange: true,
         initialContent: .init(rootView: self, dataID: dataID)))
       .linkDisplayLifecycle()
   }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/SwiftUI.View+ItemModel.swift
@@ -21,6 +21,7 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
+        forceLayoutOnLayoutMarginsChange: false,
         initialContent: .init(rootView: self, dataID: dataID)))
       .linkDisplayLifecycle()
   }

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SwiftUI.View+SupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/SwiftUI.View+SupplementaryItemModel.swift
@@ -21,6 +21,7 @@ extension View {
       content: .init(rootView: self, dataID: dataID),
       style: .init(
         reuseBehavior: reuseBehavior,
+        forceLayoutOnLayoutMarginsChange: false,
         initialContent: .init(rootView: self, dataID: dataID)))
       .linkDisplayLifecycle()
   }


### PR DESCRIPTION
## Change summary
This PR fixes the timing of layout and size invalidation when the layout margins change on an `EpoxySwiftUIHostingView`. For now, this only affects bar models, since those seem more likely to benefit from this change due to the the timing of layout margins being set during view controller transitions.

| Before | After |
| ---- | ---- |
| ![52516e8e-8764-49e3-afce-17951ae23f84](https://github.com/airbnb/epoxy-ios/assets/746571/6c7eadc0-ea03-4fa5-a594-d1e07c3e6b25) | ![39230544-32fa-43b9-8e2b-425417b69d28](https://github.com/airbnb/epoxy-ios/assets/746571/e66f40e5-7e4e-44d6-aa54-f5b59f9d8f9e) | 

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [ ] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
