### PR TITLE
Add flag to disable `EpoxySwiftUIHostingController` keyboard avoidance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '14.1' # Swift 5.7 (lowest)
-        - '15.2' # Swift 5.9.2 (highest)
+        - '14.3.1' # Swift 5.8 (lowest)
+        - '15.4' # Swift 5.10 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '15.2' # Swift 5.9.2 (highest)
+        - '15.4' # Swift 5.10 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -41,8 +41,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '14.1' # Swift 5.7 (lowest)
-        - '15.2' # Swift 5.9.2 (highest)
+        - '14.3.1' # Swift 5.8 (lowest)
+        - '15.4' # Swift 5.10 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -56,8 +56,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '14.1' # Swift 5.7 (lowest)
-        - '15.2' # Swift 5.9.2 (highest)
+        - '14.3.1' # Swift 5.8 (lowest)
+        - '15.4' # Swift 5.10 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5 (lowest)
-        - '14.0.1' # Swift 5.7 (highest)
+        - '14.1' # Swift 5.7 (lowest)
+        - '15.2' # Swift 5.9.2 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '14.0.1' # Swift 5.7 (highest)
+        - '15.2' # Swift 5.9.2 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -41,8 +41,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5 (lowest)
-        - '14.0.1' # Swift 5.7 (highest)
+        - '14.1' # Swift 5.7 (lowest)
+        - '15.2' # Swift 5.9.2 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -56,8 +56,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5  (lowest)
-        - '14.0.1' # Swift 5.7 (highest)
+        - '14.1' # Swift 5.7 (lowest)
+        - '15.2' # Swift 5.9.2 (highest)
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made new layout-based SwiftUI cell rendering option the default.
 - Fixed interaction of SwiftUI bars on visionOS
 - Added flag for forcing layout on a hosted SwiftUI view after layout margins change
+- Updated `EpoxySwiftUIHostingController` with a flag to disable its keyboard avoidance behavior
 
 ## [0.10.0](https://github.com/airbnb/epoxy-ios/compare/0.9.0...0.10.0) - 2023-06-29
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :build do
 
   desc 'Builds the EpoxyExample app'
   task :example do
-    xcodebuild 'build -scheme EpoxyExample -destination "platform=iOS Simulator,name=iPhone 12"'
+    xcodebuild 'build -scheme EpoxyExample -destination "platform=iOS Simulator,name=iPhone 14"'
   end
 end
 
@@ -23,12 +23,12 @@ namespace :test do
 
   desc 'Runs unit tests'
   task :unit do
-    xcodebuild 'test -scheme EpoxyTests -destination "platform=iOS Simulator,name=iPhone 12"'
+    xcodebuild 'test -scheme EpoxyTests -destination "platform=iOS Simulator,name=iPhone 14"'
   end
 
   desc 'Runs performance tests'
   task :performance do
-    xcodebuild 'test -scheme PerformanceTests -destination "platform=iOS Simulator,name=iPhone 12"'
+    xcodebuild 'test -scheme PerformanceTests -destination "platform=iOS Simulator,name=iPhone 14"'
   end
 end
 

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -19,7 +19,7 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
 
   /// Creates a `UIHostingController` that optionally ignores the `safeAreaInsets` when laying out
   /// its contained `RootView`.
-  public convenience init(rootView: Content, ignoreSafeArea: Bool, ignoreKeyboardAvoidance: Bool) {
+  public convenience init(rootView: Content, ignoresSafeArea: Bool, ignoresKeyboardAvoidance: Bool) {
     self.init(rootView: rootView)
 
     // We unfortunately need to call a private API to disable the safe area. We can also accomplish
@@ -27,9 +27,9 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
     // `safeAreaInsets` property and returning `.zero`. An implementation of that logic is
     // available in this file in the `2d28b3181cca50b89618b54836f7a9b6e36ea78e` commit if this API
     // no longer functions in future SwiftUI versions.
-    _disableSafeArea = ignoreSafeArea
+    _disableSafeArea = ignoresSafeArea
 
-    if ignoreKeyboardAvoidance {
+    if ignoresKeyboardAvoidance {
       disableKeyboardAvoidance()
     }
   }

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -46,6 +46,8 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
     view.backgroundColor = .clear
   }
 
+  // MARK: Private
+
   /// Creates a dynamic subclass of this hosting controller's view that disables its keyboard
   /// avoidance behavior.
   /// Setting `safeAreaRegions` to `.container` also works but cannot be used since it's

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -19,7 +19,7 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
 
   /// Creates a `UIHostingController` that optionally ignores the `safeAreaInsets` when laying out
   /// its contained `RootView`.
-  public convenience init(rootView: Content, ignoreSafeArea: Bool) {
+  public convenience init(rootView: Content, ignoreSafeArea: Bool, ignoreKeyboardAvoidance: Bool) {
     self.init(rootView: rootView)
 
     // We unfortunately need to call a private API to disable the safe area. We can also accomplish
@@ -28,6 +28,10 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
     // available in this file in the `2d28b3181cca50b89618b54836f7a9b6e36ea78e` commit if this API
     // no longer functions in future SwiftUI versions.
     _disableSafeArea = ignoreSafeArea
+
+    if ignoreKeyboardAvoidance {
+      disableKeyboardAvoidance()
+    }
   }
 
   // MARK: Open
@@ -40,6 +44,52 @@ open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Con
     // other view controllers we default the background color to clear so we can see the views
     // below, e.g. to draw highlight states in a `CollectionView`.
     view.backgroundColor = .clear
+  }
+
+  /// Creates a dynamic subclass of this hosting controller's view that disables its keyboard
+  /// avoidance behavior.
+  /// Setting `safeAreaRegions` to `.container` also works but cannot be used since it's
+  /// supported on 16.4+ and we need to support older versions.
+  /// See [here](https://steipete.com/posts/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/) for more info.
+  private func disableKeyboardAvoidance() {
+    guard let viewClass = object_getClass(view) else {
+      EpoxyLogger.shared.assertionFailure("Unable to determine class of \(String(describing: view))")
+      return
+    }
+
+    let viewClassName = class_getName(viewClass)
+    let viewSubclassName = String(cString: viewClassName).appending("_IgnoresKeyboard")
+
+    // If subclass already exists, just set the class of `view` and return.
+    if let subclass = NSClassFromString(viewSubclassName) {
+      object_setClass(view, subclass)
+      return
+    }
+
+    guard let viewSubclassNameUTF8 = (viewSubclassName as NSString).utf8String else {
+      EpoxyLogger.shared.assertionFailure("Unable to get utf8String of \(viewSubclassName)")
+      return
+    }
+    guard let viewSubclass = objc_allocateClassPair(viewClass, viewSubclassNameUTF8, 0) else {
+      EpoxyLogger.shared.assertionFailure(
+        "Unable to subclass \(viewClass) with \(viewSubclassNameUTF8)")
+      return
+    }
+
+    let selector = NSSelectorFromString("keyboardWillShowWithNotification:")
+    guard let method = class_getInstanceMethod(viewClass, selector) else {
+      EpoxyLogger.shared.assertionFailure("Unable to locate method \(selector) on \(viewClass)")
+      objc_disposeClassPair(viewSubclass)
+      return
+    }
+
+    let keyboardWillShowOverride: @convention(block) (AnyObject, AnyObject) -> Void = { _, _ in }
+    let implementation = imp_implementationWithBlock(keyboardWillShowOverride)
+    let typeEncoding = method_getTypeEncoding(method)
+    class_addMethod(viewSubclass, selector, implementation, typeEncoding)
+
+    objc_registerClassPair(viewSubclass)
+    object_setClass(view, viewSubclass)
   }
 }
 #endif

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -67,8 +67,8 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     epoxyContent = EpoxyHostingContent(rootView: style.initialContent.rootView)
     viewController = EpoxySwiftUIHostingController(
       rootView: .init(content: epoxyContent, environment: epoxyEnvironment),
-      ignoreSafeArea: true,
-      ignoreKeyboardAvoidance: true)
+      ignoresSafeArea: true,
+      ignoresKeyboardAvoidance: true)
 
     dataID = style.initialContent.dataID ?? DefaultDataID.noneProvided as AnyHashable
     forceLayoutOnLayoutMarginsChange = style.forceLayoutOnLayoutMarginsChange

--- a/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -67,7 +67,8 @@ public final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableVie
     epoxyContent = EpoxyHostingContent(rootView: style.initialContent.rootView)
     viewController = EpoxySwiftUIHostingController(
       rootView: .init(content: epoxyContent, environment: epoxyEnvironment),
-      ignoreSafeArea: true)
+      ignoreSafeArea: true,
+      ignoreKeyboardAvoidance: true)
 
     dataID = style.initialContent.dataID ?? DefaultDataID.noneProvided as AnyHashable
     forceLayoutOnLayoutMarginsChange = style.forceLayoutOnLayoutMarginsChange


### PR DESCRIPTION
## Change summary

This PR fixes an issue where an `EpoxySwiftUIHostingView` used as a bottom bar was being pushed above the keyboard when presented causing layout issues with the screen. [There doesn't seem to be a way to disable this from SwiftUI](https://steipete.com/posts/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/) (`.ignoresSafeArea(.keyboard)` doesn't work) so this uses dynamic subclassing to override the hosting controller's `keyboardWillShowWithNotification` method.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [x] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [ ] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
- [x] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
