### PR TITLE
Expose CollectionViewDataSource.modifySectionsWithoutUpdating

### DIFF
--- a/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
+++ b/Sources/EpoxyCollectionView/CollectionView/CollectionView.swift
@@ -236,8 +236,7 @@ open class CollectionView: UICollectionView {
     setSections(sections, strategy: strategy)
   }
 
-  /// Updates the sections of this collection view to the provided `sections`, optionally animating
-  /// the differences from the current sections.
+  /// Updates the underlying dataSource of this collection to the provided `sections` without performing any differencing.
   public func setSections(
     _ sections: [SectionModel],
     performBatchUpdates: @escaping () -> Void
@@ -375,6 +374,8 @@ open class CollectionView: UICollectionView {
     epoxyDataSource.data?.indexPathForItem(at: path)
   }
   
+  /// Returns the `Int` index corresponding to the given section `dataID`, logging a warning if the
+  /// index corresponds to multiple items due to duplicate data IDs.
   public func indexForSection(at dataID: AnyHashable) -> Int? {
     epoxyDataSource.data?.indexForSection(at: dataID)
   }
@@ -666,6 +667,7 @@ open class CollectionView: UICollectionView {
       case .manual(newData: let data, performBatchUpdates: _):
         if initialDataNotLoaded {
           let oldData = epoxyDataSource.data ?? .make(sections: [])
+          epoxyDataSource.modifySectionsWithoutUpdating(data.sections)
           updateState = .updating(from: oldData)
           reloadData()
           completeUpdates()


### PR DESCRIPTION
Closes #175 

## Change summary

To facilitate this change, a more sequential queuedUpdate needed to be implemented such that all manual batch updates were performed in order to reach the final state.

## How was it tested?
*How did you verify that this change accomplished what you expected? Add more detail as needed.*
- [ ] Wrote automated tests
- [x] Built and ran on the iOS simulator
- [x] Built and ran on a device

## Pull request checklist
*All items in this checklist must be completed before a pull request will be reviewed.*

- [x] Risky changes have been put behind a feature flag, e.g. `CollectionViewConfiguration`
  - No "risky" changes were made. Existing functionality works as expected.
- [ ] Added a [`CHANGELOG.md` entry](https://keepachangelog.com/en/1.0.0/) in the "Unreleased" section for any library changes
