### PR TITLE
Annotate view protocols as @MainActor for strict concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed
-- 
+- Annotated the `StyledView`, `ContentConfigurableView`, and `BehaviorsConfigurableView` view protocols as `@MainActor` so their conformances are usable without warnings from consumers building under strict concurrency / the Swift 6 language mode. The model-builder DSL entry points (`itemModel`/`barModel`/`supplementaryItemModel`/`groupItem`/`swiftUIView`) remain `nonisolated`; their deferred view-construction and configuration closures bridge to the main actor with `MainActor.assumeIsolated`.
 
 ### Fixed
 - 

--- a/Sources/EpoxyBars/BarModel/EpoxyableView+BarModel.swift
+++ b/Sources/EpoxyBars/BarModel/EpoxyableView+BarModel.swift
@@ -17,7 +17,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the bar view that uniquely identifies.
   /// - Returns: A `BarModel` with an instance of this view as its bar view.
-  public static func barModel(
+  public nonisolated static func barModel(
     dataID: AnyHashable? = nil,
     content: Content,
     behaviors: Behaviors? = nil,
@@ -28,12 +28,12 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       params: style,
       content: content,
-      makeView: Self.init(style:),
+      makeView: { style in MainActor.assumeIsolated { Self(style: style) } },
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -51,7 +51,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - behaviors: The behaviors that will be applied to the bar view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: A `BarModel` with an instance of this view as its bar view.
-  public static func barModel(
+  public nonisolated static func barModel(
     dataID: AnyHashable? = nil,
     content: Content,
     behaviors: Behaviors? = nil)
@@ -61,10 +61,10 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       content: content,
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -81,7 +81,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the bar view that uniquely identifies.
   /// - Returns: A `BarModel` with an instance of this view as its bar view.
-  public static func barModel(
+  public nonisolated static func barModel(
     dataID: AnyHashable? = nil,
     behaviors: Behaviors? = nil,
     style: Style)
@@ -89,9 +89,9 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   {
     BarModel<Self>(dataID: dataID)
       .styleID(style)
-      .makeView { Self(style: style) }
+      .makeView { MainActor.assumeIsolated { Self(style: style) } }
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -112,14 +112,14 @@ extension StyledView
   ///   - behaviors: The behaviors that will be applied to the bar view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: A `BarModel` with an instance of this view as its bar view.
-  public static func barModel(
+  public nonisolated static func barModel(
     dataID: AnyHashable? = nil,
     behaviors: Behaviors? = nil)
     -> BarModel<Self>
   {
     BarModel<Self>(dataID: dataID)
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }

--- a/Sources/EpoxyCollectionView/Models/ItemModel/EpoxyableView+ItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/ItemModel/EpoxyableView+ItemModel.swift
@@ -17,7 +17,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the item view that uniquely identifies.
   /// - Returns: An `ItemModel` with an instance of this view as its item view.
-  public static func itemModel(
+  public nonisolated static func itemModel(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil,
@@ -28,12 +28,12 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       params: style,
       content: content,
-      makeView: Self.init(style:),
+      makeView: { style in MainActor.assumeIsolated { Self(style: style) } },
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -51,7 +51,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - behaviors: The behaviors that will be applied to the item view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: An `ItemModel` with an instance of this view as its item view.
-  public static func itemModel(
+  public nonisolated static func itemModel(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil)
@@ -61,10 +61,10 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       content: content,
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -81,7 +81,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the item view that uniquely identifies.
   /// - Returns: An `ItemModel` with an instance of this view as its item view.
-  public static func itemModel(
+  public nonisolated static func itemModel(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil,
     style: Style)
@@ -89,9 +89,9 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   {
     ItemModel<Self>(dataID: dataID)
       .styleID(style)
-      .makeView { Self(style: style) }
+      .makeView { MainActor.assumeIsolated { Self(style: style) } }
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -112,14 +112,14 @@ extension StyledView
   ///   - behaviors: The behaviors that will be applied to the item view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: An `ItemModel` with an instance of this view as its item view.
-  public static func itemModel(
+  public nonisolated static func itemModel(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil)
     -> ItemModel<Self>
   {
     ItemModel<Self>(dataID: dataID)
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }

--- a/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/EpoxyableView+SupplementaryItemModel.swift
+++ b/Sources/EpoxyCollectionView/Models/SupplementaryItemModel/EpoxyableView+SupplementaryItemModel.swift
@@ -17,7 +17,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the item view that uniquely identifies.
   /// - Returns: An `SupplementaryItemModel` with an instance of this view as its item view.
-  public static func supplementaryItemModel(
+  public nonisolated static func supplementaryItemModel(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil,
@@ -28,12 +28,12 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       params: style,
       content: content,
-      makeView: Self.init(style:),
+      makeView: { style in MainActor.assumeIsolated { Self(style: style) } },
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -51,7 +51,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - behaviors: The behaviors that will be applied to the item view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: An `SupplementaryItemModel` with an instance of this view as its item view.
-  public static func supplementaryItemModel(
+  public nonisolated static func supplementaryItemModel(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil)
@@ -61,10 +61,10 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       content: content,
       setContent: { context, content in
-        context.view.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.view.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -81,7 +81,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///     method whenever this model is updated. Defaults to no behaviors.
   ///   - style: The style of the item view that uniquely identifies.
   /// - Returns: An `SupplementaryItemModel` with an instance of this view as its item view.
-  public static func supplementaryItemModel(
+  public nonisolated static func supplementaryItemModel(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil,
     style: Style)
@@ -89,9 +89,9 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   {
     SupplementaryItemModel<Self>(dataID: dataID)
       .styleID(style)
-      .makeView { Self(style: style) }
+      .makeView { MainActor.assumeIsolated { Self(style: style) } }
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }
@@ -112,14 +112,14 @@ extension StyledView
   ///   - behaviors: The behaviors that will be applied to the item view via the `setBehaviors(_:)`
   ///     method whenever this model is updated. Defaults to no behaviors.
   /// - Returns: An `SupplementaryItemModel` with an instance of this view as its item view.
-  public static func supplementaryItemModel(
+  public nonisolated static func supplementaryItemModel(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil)
     -> SupplementaryItemModel<Self>
   {
     SupplementaryItemModel<Self>(dataID: dataID)
       .setBehaviors { context in
-        context.view.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.view.setBehaviors(behaviors) }
       }
   }
 }

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -22,7 +22,8 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  public nonisolated static func swiftUIView(
+  @MainActor
+  public static func swiftUIView(
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil)
@@ -75,7 +76,8 @@ extension StyledView
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  public nonisolated static func swiftUIView(
+  @MainActor
+  public static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil)
     -> SwiftUIView<Self, Content>
@@ -123,7 +125,8 @@ extension StyledView
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public nonisolated static func swiftUIView(
+  @MainActor
+  public static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil)
     -> SwiftUIView<Self, Style>
@@ -167,7 +170,8 @@ extension StyledView
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public nonisolated static func swiftUIView(behaviors: Behaviors? = nil) -> SwiftUIView<Self, Void> {
+  @MainActor
+  public static func swiftUIView(behaviors: Behaviors? = nil) -> SwiftUIView<Self, Void> {
     SwiftUIView {
       MainActor.assumeIsolated { Self() }
     }

--- a/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -22,30 +22,34 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  public static func swiftUIView(
+  public nonisolated static func swiftUIView(
     content: Content,
     style: Style,
     behaviors: Behaviors? = nil)
     -> SwiftUIView<Self, (content: Content, style: Style)>
   {
     SwiftUIView(storage: (content: content, style: style)) {
-      let view = Self(style: style)
-      view.setContent(content, animated: false)
-      return view
+      MainActor.assumeIsolated {
+        let view = Self(style: style)
+        view.setContent(content, animated: false)
+        return view
+      }
     }
     .configure { context in
-      // We need to create a new view instance when the style changes.
-      if context.oldStorage.style != style {
-        context.view = Self(style: style)
-        context.view.setContent(content, animated: context.animated)
-      }
-      // Otherwise, if the just the content changes, we need to update it.
-      else if context.oldStorage.content != content {
-        context.view.setContent(content, animated: context.animated)
-        context.container.invalidateIntrinsicContentSize()
-      }
+      MainActor.assumeIsolated {
+        // We need to create a new view instance when the style changes.
+        if context.oldStorage.style != style {
+          context.view = Self(style: style)
+          context.view.setContent(content, animated: context.animated)
+        }
+        // Otherwise, if the just the content changes, we need to update it.
+        else if context.oldStorage.content != content {
+          context.view.setContent(content, animated: context.animated)
+          context.container.invalidateIntrinsicContentSize()
+        }
 
-      context.view.setBehaviors(behaviors)
+        context.view.setBehaviors(behaviors)
+      }
     }
   }
 }
@@ -71,24 +75,28 @@ extension StyledView
   /// ```
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
-  public static func swiftUIView(
+  public nonisolated static func swiftUIView(
     content: Content,
     behaviors: Behaviors? = nil)
     -> SwiftUIView<Self, Content>
   {
     SwiftUIView(storage: content) {
-      let view = Self()
-      view.setContent(content, animated: false)
-      return view
+      MainActor.assumeIsolated {
+        let view = Self()
+        view.setContent(content, animated: false)
+        return view
+      }
     }
     .configure { context in
-      // We need to update the content of the existing view when the content is updated.
-      if context.oldStorage != content {
-        context.view.setContent(content, animated: context.animated)
-        context.container.invalidateIntrinsicContentSize()
-      }
+      MainActor.assumeIsolated {
+        // We need to update the content of the existing view when the content is updated.
+        if context.oldStorage != content {
+          context.view.setContent(content, animated: context.animated)
+          context.container.invalidateIntrinsicContentSize()
+        }
 
-      context.view.setBehaviors(behaviors)
+        context.view.setBehaviors(behaviors)
+      }
     }
   }
 }
@@ -115,21 +123,23 @@ extension StyledView
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public static func swiftUIView(
+  public nonisolated static func swiftUIView(
     style: Style,
     behaviors: Behaviors? = nil)
     -> SwiftUIView<Self, Style>
   {
     SwiftUIView(storage: style) {
-      Self(style: style)
+      MainActor.assumeIsolated { Self(style: style) }
     }
     .configure { context in
-      // We need to create a new view instance when the style changes.
-      if context.oldStorage != style {
-        context.view = Self(style: style)
-      }
+      MainActor.assumeIsolated {
+        // We need to create a new view instance when the style changes.
+        if context.oldStorage != style {
+          context.view = Self(style: style)
+        }
 
-      context.view.setBehaviors(behaviors)
+        context.view.setBehaviors(behaviors)
+      }
     }
   }
 }
@@ -157,12 +167,14 @@ extension StyledView
   /// MyView.swiftUIView(…).sizing(.intrinsicSize)
   /// ```
   /// The sizing defaults to `.automatic`.
-  public static func swiftUIView(behaviors: Behaviors? = nil) -> SwiftUIView<Self, Void> {
+  public nonisolated static func swiftUIView(behaviors: Behaviors? = nil) -> SwiftUIView<Self, Void> {
     SwiftUIView {
-      Self()
+      MainActor.assumeIsolated { Self() }
     }
     .configure { context in
-      context.view.setBehaviors(behaviors)
+      MainActor.assumeIsolated {
+        context.view.setBehaviors(behaviors)
+      }
     }
   }
 }

--- a/Sources/EpoxyCore/Views/BehaviorsConfigurableView.swift
+++ b/Sources/EpoxyCore/Views/BehaviorsConfigurableView.swift
@@ -18,6 +18,7 @@
 /// - SeeAlso: `ContentConfigurableView`
 /// - SeeAlso: `StyledView`
 /// - SeeAlso: `EpoxyableView`
+@MainActor
 public protocol BehaviorsConfigurableView: ViewType {
   /// The non-`Equatable` properties that can be changed over of the lifecycle this View's
   /// instances, e.g. callback closures or delegates.

--- a/Sources/EpoxyCore/Views/ContentConfigurableView.swift
+++ b/Sources/EpoxyCore/Views/ContentConfigurableView.swift
@@ -17,6 +17,7 @@
 /// - SeeAlso: `BehaviorsConfigurableView`
 /// - SeeAlso: `StyledView`
 /// - SeeAlso: `EpoxyableView`
+@MainActor
 public protocol ContentConfigurableView: ViewType {
   /// The `Equatable` properties that can be updated on instances of this view, e.g. text `String`s
   /// or image `URL`s.

--- a/Sources/EpoxyCore/Views/StyledView.swift
+++ b/Sources/EpoxyCore/Views/StyledView.swift
@@ -21,6 +21,7 @@
 /// - SeeAlso: `ContentConfigurableView`
 /// - SeeAlso: `BehaviorsConfigurableView`
 /// - SeeAlso: `EpoxyableView`
+@MainActor
 public protocol StyledView: ViewType {
   /// The style type of this view, passed into its initializer to configure the resulting instance.
   ///

--- a/Sources/EpoxyLayoutGroups/Extensions/EpoxyableView+GroupItem.swift
+++ b/Sources/EpoxyLayoutGroups/Extensions/EpoxyableView+GroupItem.swift
@@ -12,7 +12,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - behaviors: the behaviors for the view
   ///   - style: the style for the view
   /// - Returns: a group item model representing the view
-  public static func groupItem(
+  public nonisolated static func groupItem(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil,
@@ -23,12 +23,12 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
       dataID: dataID,
       params: style,
       content: content,
-      make: { Self(style: $0) },
+      make: { style in MainActor.assumeIsolated { Self(style: style) } },
       setContent: { context, content in
-        context.constrainable.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.constrainable.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.constrainable.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.constrainable.setBehaviors(behaviors) }
       }
   }
 }
@@ -40,7 +40,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - content: the content for this item's view
   ///   - behaviors: the behaviors for the view
   /// - Returns: a group item model representing the view
-  public static func groupItem(
+  public nonisolated static func groupItem(
     dataID: AnyHashable,
     content: Content,
     behaviors: Behaviors? = nil)
@@ -49,12 +49,12 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
     GroupItem<Self>(
       dataID: dataID,
       content: content,
-      make: { Self() },
+      make: { MainActor.assumeIsolated { Self() } },
       setContent: { context, content in
-        context.constrainable.setContent(content, animated: context.animated)
+        MainActor.assumeIsolated { context.constrainable.setContent(content, animated: context.animated) }
       })
       .setBehaviors { context in
-        context.constrainable.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.constrainable.setBehaviors(behaviors) }
       }
   }
 }
@@ -66,7 +66,7 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   ///   - behaviors: the behaviors for the view
   ///   - style: the style for the view
   /// - Returns: a group item model representing the view
-  public static func groupItem(
+  public nonisolated static func groupItem(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil,
     style: Style)
@@ -74,9 +74,9 @@ extension StyledView where Self: BehaviorsConfigurableView & ContentConfigurable
   {
     GroupItem<Self>(
       dataID: dataID,
-      make: { Self(style: style) })
+      make: { MainActor.assumeIsolated { Self(style: style) } })
       .setBehaviors { context in
-        context.constrainable.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.constrainable.setBehaviors(behaviors) }
       }
   }
 }
@@ -92,16 +92,16 @@ extension StyledView
   ///   - dataID: the unique identifier for this item
   ///   - behaviors: the behaviors for the view
   /// - Returns: a group item model representing the view
-  public static func groupItem(
+  public nonisolated static func groupItem(
     dataID: AnyHashable,
     behaviors: Behaviors? = nil)
     -> GroupItem<Self>
   {
     GroupItem<Self>(
       dataID: dataID,
-      make: { Self() })
+      make: { MainActor.assumeIsolated { Self() } })
       .setBehaviors { context in
-        context.constrainable.setBehaviors(behaviors)
+        MainActor.assumeIsolated { context.constrainable.setBehaviors(behaviors) }
       }
   }
 }


### PR DESCRIPTION
This is part of work incrementally updating the Airbnb codebase to adopt Swift Concurrency. I found that a number of new warnings are generated when we enable the [`InferIsolatedConformances` Swift feature](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md). 

## Summary

Marks the three view protocols — `StyledView`, `ContentConfigurableView`, and `BehaviorsConfigurableView` — as `@MainActor`.

These protocols all refine `ViewType` (`UIView`/`NSView`), so every conformer is already main-actor-isolated in practice. Without the explicit annotation, the compiler infers a *main-actor-isolated conformance*, and consumers building under strict concurrency (or the Swift 6 language mode) get `main actor-isolated conformance of '…' to '…' cannot be used in a nonisolated context` warnings/errors wherever those conformances are used. Annotating the protocols makes the isolation explicit and lets downstream strict-concurrency modules consume Epoxy views cleanly.

## What changed

- `@MainActor` on `StyledView` / `ContentConfigurableView` / `BehaviorsConfigurableView`.
- The model-builder DSL entry points stay **`nonisolated`** (`itemModel` / `barModel` / `supplementaryItemModel` / `groupItem` / `swiftUIView`), so existing call sites are unaffected. Their deferred view-construction / configuration closures (`makeView` / `setContent` / `setBehaviors`) bridge to the main actor with `MainActor.assumeIsolated`, which is sound because Epoxy applies views on the main thread.

Keeping the DSL methods nonisolated is deliberate: it preserves the existing (large) set of call sites that build models from nonisolated contexts, and it keeps the model value types free of a main-actor-isolated stored closure (which would otherwise force `Sendable` requirements on `Content` and break Epoxy's off-main diffing).

## Scope / non-goals

This is a **targeted** change to the view-protocol conformance surface that downstream consumers depend on. It does **not** make Epoxy itself build cleanly under full strict concurrency — `EpoxyCore`'s SwiftUI measurement utilities, `EpoxyLayoutGroups`, and some global mutable state still emit strict-concurrency warnings and would need separate follow-ups. I scoped this PR to the view protocols to keep it reviewable and non-breaking; happy to follow up on the rest if you'd like a broader concurrency migration.

## Testing

- `xcodebuild build -scheme Epoxy -destination 'generic/platform=iOS Simulator'` — succeeds.
- `xcodebuild test -scheme EpoxyTests -destination 'platform=iOS Simulator,name=iPhone 16'` — all 286 tests pass.

## Notes for reviewers

`@MainActor` on a public protocol is source-affecting for external strict-concurrency adopters, so this is worth a deliberate look re: versioning (it builds fine for existing non-strict consumers). Opening as a draft to get your take on the approach and scope before polishing.

## Please Review

@bryankeller @brynbodayle 